### PR TITLE
Refuse a callable no container of the app can unpickle

### DIFF
--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -346,6 +346,17 @@ or `Runner` in it). It complements rather than replaces `Builder.setup(tasks)`
 Define it in a module importable inside the container — it is pickled by
 reference, like `worker_selector`.
 
+**Placement rule for all five callables** (`container_setup`,
+`worker_selector`, `limit_key_selector`, `build_function`, `run_function`):
+define them in an importable module of your own package and _import_ them
+into the file you deploy. They are cloudpickled into the `serialized=True`
+functions, and cloudpickle stores a module-level callable (or the class of
+a callable instance) as a reference to its defining module. `stardag modal
+deploy path/to/app.py` loads that file under the module name `app`, so a
+`def` written there pickles as `app.<name>`, deploys cleanly, and then
+fails in every container with `ModuleNotFoundError: No module named 'app'`.
+`StardagApp(...)` raises `SerializedCallablePlacementError` for this.
+
 Worker executions are **detached** Modal function calls by default: they
 survive orchestrator restarts (resumed builds re-attach instead of
 re-executing), are explicitly cancellable, and workers self-report their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.20.1] — 2026-08-28
+
 ### SDK
 
 - **`StardagApp(...)` now refuses a callable no container could unpickle.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`StardagApp(...)` now refuses a callable no container could unpickle.**
+  Everything an app passes — `container_setup`, `worker_selector`,
+  `limit_key_selector`, `build_function`, `run_function` — is cloudpickled
+  into the `serialized=True` functions `finalize()` registers, and
+  cloudpickle stores a module-level callable (or the class of a callable
+  instance) as a _reference_ to its defining module.
+  `stardag modal deploy path/to/app.py` loads the entry point under a module
+  name taken from the file name, so a `def` written in `app.py` pickles as
+  `app.<name>` — a module that exists only in the deploying process. The app
+  deployed cleanly and then every function carrying that callable died at
+  hydration with `ModuleNotFoundError: No module named 'app'`, before
+  reaching any of the app's own code. The damage was partial and delayed:
+  `build` and `worker_*` often survived, because their closures reach the
+  app's package modules anyway, while the scheduled reactive functions did
+  not — so an app could look healthy with its scheduler dead.
+
+  This is now a `SerializedCallablePlacementError` at `StardagApp(...)`,
+  naming the callable, the module and the fix. It raises rather than warns:
+  unlike the `task_modules` coverage warning there is no degraded-but-working
+  path on the other side of it.
+
+  Lambdas, closures and anything defined in `__main__` are **not** rejected —
+  cloudpickle writes those out by value, so they need no import in the
+  container and work today. A `functools.partial` or a bound method is
+  itself by value but carries a reference to what it wraps, so the check
+  looks through both.
+
+  Docs: the placement rule was stated only on `ContainerSetup`, which read as
+  though it were specific to the hook. It now covers all five parameters, and
+  the Modal how-to gained a section stating the deploy CLI's import naming
+  explicitly — the part no app author can infer from their own code.
+
 ## [0.20.0] — 2026-08-14
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,92 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.20.1 — A callable your containers cannot import is now refused at deploy
+
+Nearly additive. The one behaviour change: `StardagApp(...)` raises
+`SerializedCallablePlacementError` for a callable defined in the file you
+deploy. Such an app deployed cleanly before, and then failed in its
+containers — so nothing that worked stops working.
+
+**If you define `container_setup`, `worker_selector`, `limit_key_selector`,
+a custom `build_function` or a custom `run_function` directly in the file you
+pass to `stardag modal deploy`, move it into an importable module.** That
+app is already broken; this release tells you so at the point you write it
+instead of minutes later, in a container, in a function you were not
+watching.
+
+```python
+# my_app/routing.py — a module in your package, added to the image with
+# add_local_python_source(...)
+def worker_selector(task):
+    return "gpu" if task.get_name() == "TrainModel" else "default"
+
+
+# my_app/app.py — the file you deploy
+from my_app.routing import worker_selector  # imported, not defined here
+
+app = StardagApp(
+    "my-app",
+    worker_selector=worker_selector,
+    builder_settings=FunctionSettings(image=image),
+    worker_settings={"default": FunctionSettings(image=image)},
+)
+```
+
+### What went wrong
+
+`finalize()` registers every function with `serialized=True`, so a container
+receives a pickled closure rather than importing the module your app was
+declared in. Cloudpickle stores a module-level callable — or the _class_ of
+a callable instance, such as a `Builder` or `Runner` subclass — as a
+reference to its defining module, and the container resolves that reference
+by importing the module by name.
+
+`stardag modal deploy path/to/app.py` loads that file under a module name
+taken from the file name. A `def` written in `app.py` therefore pickles as
+`app.<name>`, and `app` is a name that exists only in the process that ran
+the deploy:
+
+```
+ModuleNotFoundError: No module named 'app'
+modal.exception.DeserializationError: Deserialization failed because the
+'app' module is not available in the remote environment.
+```
+
+Three things made this hard to catch. Every deploy-time signal is green —
+the deploy succeeds and prints the full function list, and the `StardagApp`
+object really is correctly wired in the deploying process. The damage is
+partial: `build` and `worker_*` usually survive, because their closures
+reach your package's modules anyway, while the scheduled reactive functions
+do not — so an app can look healthy with its scheduler dead. And the rule is
+a property of the deploy CLI, not of your app: nothing in your own code says
+"this file will be imported under the name `app`".
+
+### What is not rejected
+
+Lambdas and closures written in the entry point, and anything defined in
+`__main__`, are left alone. Cloudpickle cannot look those up by name, so it
+serialises the code object by value and no import is needed in the container.
+They work today and continue to. A `functools.partial` or a bound method is
+itself written by value but carries a reference to what it wraps, so the
+check looks through both.
+
+The check is best-effort in the same way the existing `container_setup` arity
+check is: a callable it cannot introspect is let through rather than refused
+on a guess.
+
+### Docs
+
+The placement rule was previously stated in exactly one place — the
+`ContainerSetup` docstring — which read as though it were specific to that
+hook, when all five callables carry it identically. It now appears on every
+one of them, and the Modal how-to gains a section, [Where to define what you
+pass to
+`StardagApp`](https://stardag-dev.github.io/stardag/how-to/integrate-modal/#where-to-define-what-you-pass-to-stardagapp),
+that states the deploy CLI's import naming explicitly.
+
+---
+
 ## v0.20.0 — Container setup you can actually rely on, in every Modal container
 
 Additive. Nothing to migrate: an app that does not pass `container_setup`

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1114,6 +1114,69 @@ app = sd_modal.StardagApp(
 )
 ```
 
+## Where to define what you pass to `StardagApp`
+
+Every callable a `StardagApp` is handed — `container_setup`,
+`worker_selector`, `limit_key_selector`, `build_function` and
+`run_function` — must be defined in a **module the container can import**.
+That means one of your own package's modules, added to the image with
+`add_local_python_source(...)`, and _imported_ into the file you deploy.
+
+**Not** the deploy entry point itself. This is the one placement rule you
+cannot infer from your own code, so it is worth stating plainly:
+
+```{.python notest}
+# my_app/routing.py — importable, and in the image
+def worker_selector(task):
+    return "gpu" if task.get_name() == "TrainModel" else "default"
+
+
+# my_app/app.py — the file you pass to `stardag modal deploy`
+from my_app.routing import worker_selector  # ✅ imported, not defined here
+
+app = sd_modal.StardagApp(
+    "stardag-poc",
+    worker_selector=worker_selector,
+    builder_settings=sd_modal.FunctionSettings(image=image),
+    worker_settings={
+        "default": sd_modal.FunctionSettings(image=image),
+        "gpu": sd_modal.FunctionSettings(image=gpu_image),
+    },
+)
+```
+
+**Why.** `StardagApp` registers its Modal functions with `serialized=True`,
+so a container receives a pickled closure rather than importing the module
+your app was declared in. Cloudpickle stores a module-level callable — or
+the _class_ of a callable instance, such as a `Builder` or `Runner`
+subclass — as a **reference to its defining module**, and the container
+resolves that reference by importing the module by name.
+
+`stardag modal deploy path/to/app.py` loads that file under a module name
+taken from the file name, so a `def` written in `app.py` pickles as
+`app.<name>`. `app` exists only in the process that ran the deploy. In a
+container the hydration fails before any of your code runs:
+
+```
+ModuleNotFoundError: No module named 'app'
+modal.exception.DeserializationError: Deserialization failed because the
+'app' module is not available in the remote environment.
+```
+
+Nothing at deploy time looks wrong — the deploy succeeds and prints the
+full function list — and the damage is partial: `build` and `worker_*`
+often survive, because their closures reach your package's modules anyway,
+while the scheduled reactive functions do not. Stardag therefore refuses
+the callable at `StardagApp(...)` with a
+`SerializedCallablePlacementError` naming the callable, the module and the
+fix, rather than letting it deploy.
+
+Lambdas and closures written in the entry point are exempt, and are not
+rejected: cloudpickle cannot look them up by name, so it serialises the
+code object by value. They work — but a lambda that _calls_ a `def` from
+the same file drags the same broken reference along with it, so importing
+from a real module is the habit worth keeping.
+
 ## Container setup: code that runs in every container
 
 Some setup is a property of the _container_, not of a build or a task:
@@ -1124,7 +1187,7 @@ validating that the environment is what you think it is. Pass it as
 reactive `tick`, `bootstrap` and `tick_watchdog`.
 
 ```{.python notest}
-# my_app/setup.py — an importable module, not the deploy script (see below)
+# my_app/setup.py — an importable module, not the deploy script (see above)
 def container_setup() -> None:
     configure_logging()
     write_credentials()
@@ -1174,14 +1237,13 @@ and then never again for the rest of that container's inputs.
 
 ### Details worth knowing
 
-- **Define it in an importable module.** Like `worker_selector` and your
-  build/run functions, the hook is captured by the serialized Modal
-  functions and pickled _by reference_ (via its class, if you pass a
-  callable instance rather than a plain function), so its defining module must be
-  importable in the container — part of the source you add via
-  `add_local_python_source(...)`, not a loose deploy script. That is also
-  what makes any module-level code in the hook's own module run in every
-  container of the app.
+- **Define it in an importable module**, not in the file you deploy — see
+  [Where to define what you pass to
+  `StardagApp`](#where-to-define-what-you-pass-to-stardagapp), which
+  applies identically to `worker_selector` and your build/run functions.
+  Importing the hook from your own package is also what makes any
+  module-level code in the hook's module run in every container of the
+  app.
 - **Once per container, not once per input.** A worker serves many tasks
   and a tick container may be reused; stardag holds the guard so you do
   not have to write one.

--- a/lib/stardag/src/stardag/_cli/modal.py
+++ b/lib/stardag/src/stardag/_cli/modal.py
@@ -37,6 +37,7 @@ from stardag._cli.credentials import (
 from stardag.config.cache import get_cached_slugs
 from stardag.config.loader import clear_config_cache, get_config
 from stardag.integration.modal import FinalizeResult, StardagApp
+from stardag.integration.modal._container_setup import _loading_deploy_entrypoint
 
 # Check if modal is available
 try:
@@ -405,7 +406,14 @@ def _import_file_or_module(file_or_module: str, use_module_mode: bool) -> object
 
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        # The name is derived from the file name, so it is importable here
+        # (this directory is on sys.path, two lines up) and almost never
+        # importable in a container. Tell the app that, so a callable
+        # *defined* in this file is refused where it is written rather
+        # than failing to unpickle in every container of the deployed app
+        # — see _validate_serialized_callable.
+        with _loading_deploy_entrypoint(module_name):
+            spec.loader.exec_module(module)
 
     return module
 

--- a/lib/stardag/src/stardag/integration/modal/__init__.py
+++ b/lib/stardag/src/stardag/integration/modal/__init__.py
@@ -69,7 +69,10 @@ from stardag.integration.modal._builder import (
     PrefectBuilder,
 )
 from stardag.integration.modal._config import get_package_deps, with_stardag_on_image
-from stardag.integration.modal._container_setup import ContainerSetup
+from stardag.integration.modal._container_setup import (
+    ContainerSetup,
+    SerializedCallablePlacementError,
+)
 from stardag.integration.modal._executor import ModalTaskExecutor
 from stardag.integration.modal._profile import get_profile_env_vars, get_profile_secret
 from stardag.integration.modal._protocols import BuildFunction, RunFunction
@@ -95,6 +98,7 @@ __all__ = [
     "BuildTriggerResult",
     "ContainerSetup",
     "ReactiveDiscovery",
+    "SerializedCallablePlacementError",
     "RunFunction",
     "StardagApp",
     "Builder",

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -42,6 +42,7 @@ from stardag.integration.modal._container_setup import (
     ContainerSetup,
     _run_container_setup,
     _validate_container_setup,
+    _validate_serialized_callable,
 )
 from stardag.integration.modal._logging import _setup_logging
 from stardag.integration.modal._metadata import (
@@ -274,6 +275,13 @@ class StardagApp:
                 property of the ``build`` container only; for setup that
                 must run in *every* container the app deploys, pass
                 ``container_setup``.
+
+                Being reached by import is also why **it must not be
+                defined in the file you deploy**: the CLI loads that file
+                under a module name taken from its name (``app.py`` ->
+                ``app``), which exists only in the deploying process. See
+                ``container_setup`` for the whole rule; it is checked here
+                and raises.
             run_function: Callable registered as the Modal worker functions.
                 Must match the ``RunFunction`` protocol:
                 ``(task) -> None``.
@@ -285,7 +293,9 @@ class StardagApp:
                 its class's) inside every ``worker_*`` container — use that,
                 or ``Runner.setup()``, for worker-specific setup such as
                 GPU init or library preloading, and ``container_setup``
-                for setup every container needs.
+                for setup every container needs. The same placement rule
+                applies: define it in an importable module, not in the
+                file you deploy.
             container_setup: Called once per container, at the top of
                 **every** function this app registers — ``build``, each
                 ``worker_*``, and the reactive ``tick``, ``bootstrap`` and
@@ -347,12 +357,31 @@ class StardagApp:
                 non-root logger will still see stardag add a root
                 ``StreamHandler``.
 
-                Like ``worker_selector`` and the callables above, this is
-                captured by the serialized Modal functions, so **define it
-                in a module that is importable inside the container**
-                (source added via ``add_local_python_source(...)``, not a
-                loose deploy script). That is also what makes module-level
-                code in the hook's own module run in every container.
+                **Define it in a module that is importable inside the
+                container** — source added via
+                ``add_local_python_source(...)`` — and import it into the
+                file you deploy. This applies identically to
+                ``worker_selector``, ``limit_key_selector`` and the two
+                callables above: all five are captured by the serialized
+                Modal functions, and cloudpickle stores a module-level
+                callable (or the class of a callable instance) as a
+                *reference* to its defining module, which the container
+                resolves by importing it.
+
+                Defining one in the deploy entry point is the way this
+                goes wrong, and it is not inferable from the app's own
+                code: ``stardag modal deploy path/to/app.py`` loads that
+                file under a module name taken from the file name, so a
+                ``def`` written there pickles as ``app.<name>`` and no
+                container has a module called ``app``. The deploy
+                succeeds and the affected functions then die at hydration
+                with ``ModuleNotFoundError``. Passing such a callable
+                raises :class:`SerializedCallablePlacementError` here
+                instead.
+
+                Importing the hook from your own package is also what
+                makes module-level code in the hook's own module run in
+                every container.
             builder_settings: Settings for the "build" function. Each
                 function's settings are independent — nothing is propagated
                 between them, except ``stardag_api_key_secret`` (below) and
@@ -366,6 +395,11 @@ class StardagApp:
                 about it. Passing a selector explicitly, even one that
                 always returns ``"default"``, is how to say that is
                 intended.
+
+                Carried into the serialized ``build`` and ``tick``
+                functions, so it obeys the placement rule under
+                ``container_setup``: define it in an importable module of
+                your own package, not in the file you deploy.
             tick_settings: Settings for the reactive-scheduling ``tick`` /
                 ``tick_watchdog`` functions. Defaults to ``builder_settings``
                 when not given.
@@ -424,6 +458,11 @@ class StardagApp:
                 concurrency-limit keys it runs under in reactive scheduling
                 (deployed-app configuration applied by every tick). Default:
                 no limits.
+
+                Carried into the serialized ``tick`` function, so it obeys
+                the placement rule under ``container_setup``: define it in
+                an importable module of your own package, not in the file
+                you deploy.
             task_modules: Modules whose import registers the task classes
                 this app may schedule. **Only reactive scheduling needs
                 this**: a scheduler tick reconstructs tasks from registry
@@ -524,6 +563,23 @@ class StardagApp:
         if container_setup is not None:
             _validate_container_setup(container_setup)
         self.container_setup = container_setup
+        # All five callables share one failure mode that nothing later
+        # catches: cloudpickle stores a module-level callable as a
+        # reference to its defining module, so one defined in the deploy
+        # entry point deploys cleanly and then cannot be hydrated in any
+        # container. Checked here, together, rather than per parameter —
+        # the constraint is a property of being serialized into the
+        # deployed functions, which is exactly what these five have in
+        # common.
+        for parameter, value in (
+            ("build_function", build_function),
+            ("run_function", run_function),
+            ("container_setup", container_setup),
+            ("worker_selector", worker_selector),
+            ("limit_key_selector", limit_key_selector),
+        ):
+            if value is not None:
+                _validate_serialized_callable(parameter, value)
         self._builder_settings = builder_settings
         self._worker_settings = worker_settings
         # Reactive scheduling: the "tick" function's settings (defaults to

--- a/lib/stardag/src/stardag/integration/modal/_container_setup.py
+++ b/lib/stardag/src/stardag/integration/modal/_container_setup.py
@@ -13,14 +13,27 @@ reference — reliable for ``build`` and ``worker_*`` (they close over the
 app's ``build_function`` / ``run_function``), and an accident for the
 reactive ``tick`` / ``bootstrap`` / ``tick_watchdog``. Passing
 ``StardagApp(container_setup=...)`` makes it a contract for all five.
+
+That same serialization model is why the placement guardrail lives here
+too (:func:`_validate_serialized_callable`): every callable an app hands
+``StardagApp`` is pickled into those functions by reference to its
+defining module, so where it is *defined* decides whether a container can
+hydrate the function at all.
 """
 
 from __future__ import annotations
 
+import contextlib
+import functools
+import importlib.util
 import inspect
 import logging
+import sys
 import threading
+import types
 import typing
+
+from stardag.exceptions import StardagError
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +47,9 @@ anything else in the Modal function that invoked it — see
 Like ``worker_selector`` and the app's build/run functions, this is
 captured by the serialized Modal functions and so must be defined in a
 module that is importable *inside the container* (part of the source added
-via ``add_local_python_source(...)``, not a loose deploy script). That is
+via ``add_local_python_source(...)``), and imported into the file you
+deploy rather than defined there — see
+:func:`_validate_serialized_callable`, which refuses the latter. That is
 also what makes any module-level code in the hook's own module run in
 every container of the app.
 """
@@ -88,6 +103,179 @@ def _validate_container_setup(container_setup: typing.Any) -> None:
             f"pass it — bind any configuration it needs at the call site "
             f"(a closure or functools.partial)."
         ) from e
+
+
+# =============================================================================
+# Placement: can a container import what it is asked to unpickle?
+# =============================================================================
+
+
+class SerializedCallablePlacementError(StardagError):
+    """A callable passed to ``StardagApp`` lives where no container can
+    import it.
+
+    Raised at ``StardagApp(...)``, because the deployed app would be
+    broken in a way nothing later checks: the deploy succeeds and the
+    affected functions then die on every invocation, at hydration, before
+    any of their own code runs.
+    """
+
+
+# The name the deploy CLI is currently loading an entry-point *file*
+# under. Set only for the duration of that exec (see
+# ``_loading_deploy_entrypoint``), which is when an app's ``StardagApp``
+# is constructed, and left ``None`` in every other process — including
+# every container, which imports this module from the image like any
+# other.
+#
+# It has to be told to us rather than derived. The CLI names the module
+# after the file (``modal/app.py`` -> ``app``) and puts the file's
+# directory on ``sys.path``, so from inside the process the name resolves:
+# ``importlib.util.find_spec("app")`` finds it, in ``sys.modules`` and
+# again on disk. Nothing about it looks synthetic locally; what makes it
+# unimportable is the container, where that directory is not on the path
+# and usually not in the image at all.
+_deploy_entrypoint_module: str | None = None
+
+
+@contextlib.contextmanager
+def _loading_deploy_entrypoint(module_name: str) -> typing.Iterator[None]:
+    """Record the name a deploy entry-point file is being loaded under.
+
+    Wraps the CLI's ``exec_module`` of the entry point, so any
+    ``StardagApp`` constructed while it runs can tell "defined in the
+    entry point" from "imported into it".
+
+    Restores the previous value rather than clearing it: a process that
+    loads two entry points (a test, a script deploying several apps)
+    must not have the first one's name outlive it.
+    """
+    global _deploy_entrypoint_module
+    previous = _deploy_entrypoint_module
+    _deploy_entrypoint_module = module_name
+    try:
+        yield
+    finally:
+        _deploy_entrypoint_module = previous
+
+
+def _pickled_by_reference(value: typing.Any) -> tuple[str, str] | None:
+    """The ``(module, qualname)`` a container must import to unpickle ``value``.
+
+    ``None`` when there is none — cloudpickle would write ``value`` out by
+    value, so the payload is self-contained and no import is needed.
+
+    This mirrors what cloudpickle decides, because that is the thing that
+    actually matters, and it differs from "which module was this written
+    in" in both directions:
+
+    - A **module-level def**, or the **class of a callable instance**, is
+      stored as a bare ``module.qualname`` reference. This is the case
+      that breaks, and the common one: a ``def`` in the deploy entry
+      point, or a ``Builder``/``Runner`` subclass defined there.
+    - A **lambda**, a **closure**, or anything defined in ``__main__`` is
+      written out by value — cloudpickle cannot look it up again by name,
+      so it serialises the code object. Those work, and rejecting them
+      would break apps that are fine today.
+    - A ``functools.partial`` or a **bound method** is itself by value but
+      wraps something that may not be, so we look through to the wrapped
+      callable. ``functools.partial`` matters here in particular: it is
+      what an app is told to reach for when a hook needs configuration
+      bound to it.
+
+    Best-effort by design. Anything it cannot decide reads as ``None`` and
+    is let through, on the same principle as the arity check above: a
+    guess is not worth refusing a deploy over.
+    """
+    if isinstance(value, functools.partial):
+        return _pickled_by_reference(value.func)
+    if isinstance(value, types.MethodType):
+        # A bound method reduces to (getattr, (__self__, name)); it is
+        # __self__ — the instance, or the class for a classmethod — that
+        # carries the reference.
+        return _pickled_by_reference(value.__self__)
+    target = value if isinstance(value, (types.FunctionType, type)) else type(value)
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None)
+    if not isinstance(module, str) or not isinstance(qualname, str):
+        return None
+    if module == "__main__":
+        return None
+    defining_module = sys.modules.get(module)
+    if defining_module is None:
+        # __module__ names something not imported in this process. The
+        # round-trip below cannot be confirmed, but the name is still what
+        # a container would be asked for, so report it and let the
+        # caller's importability check speak.
+        return module, qualname
+    try:
+        found = functools.reduce(getattr, qualname.split("."), defining_module)
+    except AttributeError:
+        # Not reachable under its own name (a lambda, a closure, a
+        # dynamically built callable) -> cloudpickle writes it by value.
+        return None
+    return (module, qualname) if found is target else None
+
+
+def _validate_serialized_callable(parameter: str, value: typing.Any) -> None:
+    """Reject a callable no container of the app could unpickle.
+
+    Everything a ``StardagApp`` is handed — ``container_setup``,
+    ``worker_selector``, ``limit_key_selector``, ``build_function``,
+    ``run_function`` — is cloudpickled into the ``serialized=True``
+    functions ``finalize()`` registers, and cloudpickle stores a
+    module-level callable as a *reference* to its defining module. A
+    container that cannot import that module cannot hydrate the function,
+    and fails before reaching any of the app's own code::
+
+        ModuleNotFoundError: No module named 'app'
+
+    The mistake this catches is defining such a callable in the deploy
+    entry point itself. ``stardag modal deploy path/to/app.py`` loads that
+    file under the module name ``app``, so the callable pickles as
+    ``app.<name>`` — a name that exists only in the deploying process.
+    Every deploy-time signal stays green, and the damage shows up later,
+    per function: ``build`` and ``worker_*`` often survive (their closures
+    reach package modules anyway) while the scheduled reactive functions
+    do not.
+
+    Raises rather than warns. Unlike the ``task_modules`` coverage
+    warning, there is no degraded-but-working path on the other side of
+    this one: the function is guaranteed to fail in every container, on
+    every invocation, and a warning would be read at the same moment the
+    outage is — which is to say, afterwards.
+    """
+    reference = _pickled_by_reference(value)
+    if reference is None:
+        return
+    module, qualname = reference
+    fix = (
+        f"Move {qualname} into a module of your own package — one the "
+        f"image adds with add_local_python_source(...) — and import it "
+        f"into the entry point instead of defining it there."
+    )
+    if module == _deploy_entrypoint_module:
+        raise SerializedCallablePlacementError(
+            f"{parameter} pickles as {module}.{qualname}, and {module!r} is "
+            f"the name this deploy loaded the entry-point file under — not a "
+            f"module in the app's image. Everything passed to StardagApp is "
+            f"cloudpickled into the functions it deploys, and a module-level "
+            f"callable is stored as a reference to its defining module, so "
+            f"every container that hydrates it would fail with "
+            f'"ModuleNotFoundError: No module named {module!r}". {fix}'
+        )
+    try:
+        spec = importlib.util.find_spec(module)
+    except (ImportError, ValueError):
+        spec = None
+    if spec is None:
+        raise SerializedCallablePlacementError(
+            f"{parameter} pickles as {module}.{qualname}, and {module!r} is "
+            f"not importable even here. Everything passed to StardagApp is "
+            f"cloudpickled into the functions it deploys, and a module-level "
+            f"callable is stored as a reference to its defining module, so a "
+            f"container could not import it either. {fix}"
+        )
 
 
 def _already_run(container_setup: ContainerSetup) -> bool:

--- a/lib/stardag/src/stardag/integration/modal/_protocols.py
+++ b/lib/stardag/src/stardag/integration/modal/_protocols.py
@@ -46,6 +46,11 @@ class BuildFunction(typing.Protocol):
     ``build`` container only; for setup every container of the app needs —
     workers and the reactive functions included — pass
     ``StardagApp(container_setup=...)``.
+
+    That import is also why the module has to be one the container *has*:
+    define a custom build function in your own package and import it into
+    the file you deploy, never directly in that file (see
+    ``StardagApp(container_setup=...)`` for the rule and the error).
     """
 
     def __call__(
@@ -77,7 +82,9 @@ class RunFunction(typing.Protocol):
     defined will execute inside every ``worker_*`` container before the
     function is called, by the same mechanism as ``BuildFunction`` above —
     use it for worker-specific setup. For setup every container of the app
-    needs, pass ``StardagApp(container_setup=...)``.
+    needs, pass ``StardagApp(container_setup=...)``. The same placement
+    rule applies: define it in an importable module of your own package,
+    not in the file you deploy.
 
     Args (of ``__call__``):
         task: The task instance to execute.

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1,6 +1,10 @@
 """Tests for StardagApp build_function and run_function customization."""
 
 import contextlib
+import importlib.util
+import io
+import pickletools
+import sys
 import threading
 import time
 import typing
@@ -25,11 +29,13 @@ from stardag.integration.modal import (
     FunctionSettings,
     RunFunction,
     Runner,
+    SerializedCallablePlacementError,
     StardagApp,
 )
 from stardag.integration.modal._builder import _default_build
 from stardag.integration.modal import _container_setup as _container_setup_module
 from stardag.integration.modal._container_setup import (
+    _loading_deploy_entrypoint,
     _reset_container_setup_for_testing,
 )
 from stardag.integration.modal._runner import _default_run
@@ -3059,3 +3065,253 @@ class TestUnreachableWorkerWarning:
             _finalize_capturing_functions(app)
 
         assert "worker_selector" not in caplog.text
+
+
+ENTRY_POINT_SOURCE = '''\
+"""Stands in for a deploy entry point — a conventional modal/app.py."""
+
+import functools
+
+
+def pick_worker(task):
+    return "default"
+
+
+def setup():
+    return None
+
+
+pick_worker_partial = functools.partial(pick_worker)
+
+pick_worker_lambda = lambda task: "default"  # noqa: E731
+
+
+def _make_closure():
+    def pick(task):
+        return "default"
+
+    return pick
+
+
+pick_worker_closure = _make_closure()
+
+
+class Selector:
+    def __call__(self, task):
+        return "default"
+
+
+selector_instance = Selector()
+'''
+
+
+@pytest.fixture
+def entry_point(tmp_path):
+    """A module loaded exactly the way ``stardag modal deploy`` loads one.
+
+    ``_import_file_or_module`` names the module after the file, puts its
+    directory on ``sys.path`` and registers it in ``sys.modules`` — so
+    "app" is a perfectly resolvable module *in this process*, and that is
+    the whole trap. The fixture reproduces that, and the surrounding
+    ``_loading_deploy_entrypoint`` scope, without shelling out to Modal.
+    """
+    path = tmp_path / "app.py"
+    path.write_text(ENTRY_POINT_SOURCE)
+    spec = importlib.util.spec_from_file_location("app", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.modules.get("app")
+    sys.modules["app"] = module
+    sys.path.insert(0, str(tmp_path))
+    try:
+        with _loading_deploy_entrypoint("app"):
+            spec.loader.exec_module(module)
+            yield module
+    finally:
+        sys.path.remove(str(tmp_path))
+        if previous is None:
+            sys.modules.pop("app", None)
+        else:
+            sys.modules["app"] = previous
+
+
+class TestSerializedCallablePlacement:
+    """Callables an app hands ``StardagApp`` must be importable in a container.
+
+    All five are cloudpickled into the ``serialized=True`` functions
+    ``finalize()`` registers, and cloudpickle stores a module-level
+    callable as a reference to its defining module. One defined in the
+    deploy entry point therefore deploys cleanly and then cannot be
+    hydrated anywhere — the failure lands minutes later, in whichever
+    functions happen to carry it.
+    """
+
+    @staticmethod
+    def _app(**kwargs) -> StardagApp:
+        return StardagApp(
+            "test-app",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+            task_modules=[],
+            **kwargs,
+        )
+
+    # -- the failure this exists to prevent ---------------------------------
+
+    def test_entry_point_def_pickles_by_reference_to_a_module_no_container_has(
+        self, entry_point
+    ):
+        """The bug itself, pinned at the layer where it happens.
+
+        Modal serializes with its vendored cloudpickle, so this asserts
+        against the very pickler a deploy uses: a module-level def in the
+        entry point comes out as a bare ``app.pick_worker`` reference, and
+        unpickling it anywhere else means importing ``app``.
+        """
+        from modal._vendor import cloudpickle
+
+        buffer = io.BytesIO()
+        cloudpickle.CloudPickler(buffer, protocol=4).dump(entry_point.pick_worker)
+
+        globals_referenced = [
+            argument
+            for opcode, argument, _ in pickletools.genops(buffer.getvalue())
+            if opcode.name in ("SHORT_BINUNICODE", "BINUNICODE")
+        ]
+        assert globals_referenced == ["app", "pick_worker"]
+
+    def test_the_module_resolves_locally_which_is_why_find_spec_cannot_catch_it(
+        self, entry_point
+    ):
+        """Why the CLI has to *tell* the app the name it loaded.
+
+        The deploying process can import ``app`` — it is in
+        ``sys.modules`` and its directory is on ``sys.path``. Nothing
+        about the name looks synthetic from here; only the container
+        knows it is not real.
+        """
+        assert importlib.util.find_spec("app") is not None
+
+    # -- the guardrail ------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "parameter",
+        [
+            "build_function",
+            "run_function",
+            "container_setup",
+            "worker_selector",
+            "limit_key_selector",
+        ],
+    )
+    def test_rejects_a_def_from_the_entry_point_for_every_parameter(
+        self, entry_point, parameter
+    ):
+        """All five are serialized the same way, so all five are checked."""
+        callable_ = (
+            entry_point.setup
+            if parameter == "container_setup"
+            else (entry_point.pick_worker)
+        )
+
+        with pytest.raises(SerializedCallablePlacementError) as excinfo:
+            self._app(**{parameter: callable_})
+
+        message = str(excinfo.value)
+        assert parameter in message
+        assert "add_local_python_source" in message
+
+    def test_the_error_names_the_callable_the_module_and_the_symptom(self, entry_point):
+        """An author reading this should not have to infer any of it: what
+        was rejected, the module name that will not exist, and the
+        ``ModuleNotFoundError`` they would otherwise have gone looking
+        for."""
+        with pytest.raises(SerializedCallablePlacementError) as excinfo:
+            self._app(worker_selector=entry_point.pick_worker)
+
+        message = str(excinfo.value)
+        assert "pick_worker" in message
+        assert "'app'" in message
+        assert "No module named 'app'" in message
+
+    def test_rejects_an_instance_of_a_class_defined_in_the_entry_point(
+        self, entry_point
+    ):
+        """A ``Builder``/``Runner`` subclass is the documented way to
+        customise a build, and it fails identically: the instance pickles
+        as a reconstruction of its class, and the class is the reference.
+        """
+        with pytest.raises(SerializedCallablePlacementError, match="Selector"):
+            self._app(worker_selector=entry_point.selector_instance)
+
+    def test_rejects_a_partial_wrapping_an_entry_point_def(self, entry_point):
+        """``functools.partial`` is what an app is pointed at for binding
+        configuration to a hook, and it is transparent to the trap: the
+        partial pickles by value but carries the reference to its func.
+        """
+        with pytest.raises(SerializedCallablePlacementError, match="pick_worker"):
+            self._app(worker_selector=entry_point.pick_worker_partial)
+
+    # -- what must keep working --------------------------------------------
+
+    def test_accepts_a_lambda_defined_in_the_entry_point(self, entry_point):
+        """cloudpickle cannot look a lambda up by name, so it writes the
+        code object out by value — no import needed in the container.
+        Rejecting these would break apps that work today.
+        """
+        self._app(worker_selector=entry_point.pick_worker_lambda)
+
+    def test_accepts_a_closure_defined_in_the_entry_point(self, entry_point):
+        """Same reason as the lambda: ``pick`` is not reachable under its
+        own qualname, so it is serialized by value."""
+        self._app(worker_selector=entry_point.pick_worker_closure)
+
+    def test_accepts_a_callable_imported_into_the_entry_point(self, entry_point):
+        """The fix the error asks for. Defined in a real, importable
+        module and merely *referenced* from the entry point."""
+        self._app(worker_selector=_importable_worker_selector)
+
+    def test_accepts_a_module_level_def_outside_a_deploy(self):
+        """Constructing an app in ordinary code — a test, a notebook, a
+        library — is untouched: nothing is loading an entry point, and the
+        module resolves."""
+        assert _container_setup_module._deploy_entrypoint_module is None
+
+        self._app(worker_selector=_importable_worker_selector)
+
+    def test_accepts_the_defaults(self, entry_point):
+        """The default build/run functions are stardag's own, and stardag
+        is in the image by construction."""
+        app = self._app()
+
+        assert app._build_function is _default_build
+        assert app._run_function is _default_run
+
+    def test_accepts_a_main_module_callable(self, entry_point, monkeypatch):
+        """``__main__`` is the one unimportable module cloudpickle already
+        handles: it refuses to reference it and falls back to pickling by
+        value. Rejecting it would be wrong, and would fire on every app
+        run as a script."""
+        monkeypatch.setattr(
+            _importable_worker_selector, "__module__", "__main__", raising=False
+        )
+
+        self._app(worker_selector=_importable_worker_selector)
+
+    def test_entry_point_name_is_restored_after_loading(self, tmp_path):
+        """Nested scopes restore rather than clear: a process deploying
+        two apps must not carry the first entry point's name into the
+        second."""
+        assert _container_setup_module._deploy_entrypoint_module is None
+
+        with _loading_deploy_entrypoint("first"):
+            with _loading_deploy_entrypoint("second"):
+                assert _container_setup_module._deploy_entrypoint_module == "second"
+            assert _container_setup_module._deploy_entrypoint_module == "first"
+
+        assert _container_setup_module._deploy_entrypoint_module is None
+
+
+def _importable_worker_selector(task) -> str:
+    """A selector living in a module a container really could import."""
+    return "default"


### PR DESCRIPTION
## The bug

Everything passed to `StardagApp` — `container_setup`, `worker_selector`,
`limit_key_selector`, `build_function`, `run_function` — is cloudpickled
into the `serialized=True` functions `finalize()` registers, and
cloudpickle stores a module-level callable (or the **class** of a callable
instance) as a *reference* to its defining module. A container hydrates
that reference by importing the module by name.

`stardag modal deploy path/to/app.py` loads the entry point under a module
name taken from the file name, so a `def` written in `app.py` pickles as
`app.<name>` — a module that exists only in the deploying process. The app
deploys cleanly, prints its full function list, and then every function
carrying that callable dies at hydration:

```
ModuleNotFoundError: No module named 'app'
modal.exception.DeserializationError: Deserialization failed because the
'app' module is not available in the remote environment.
```

Three things make it hard to catch. Every deploy-time signal is green.
The damage is partial — `build` and `worker_*` usually survive, because
their closures reach the app's package modules anyway, while the scheduled
reactive functions do not, so an app can look healthy with its scheduler
dead. And the rule is a property of the deploy CLI, not of the app:
nothing in the author's own code says "this file will be imported under
the name `app`".

## The fix

`StardagApp(...)` now raises `SerializedCallablePlacementError` for all
five parameters, naming the callable, the module and the fix. It raises
rather than warns: unlike the `task_modules` coverage warning there is no
degraded-but-working path on the other side of this one, and a warning
would be read at the same moment the outage is.

```
worker_selector pickles as app.pick_worker, and 'app' is the name this
deploy loaded the entry-point file under — not a module in the app's
image. Everything passed to StardagApp is cloudpickled into the functions
it deploys, and a module-level callable is stored as a reference to its
defining module, so every container that hydrates it would fail with
"ModuleNotFoundError: No module named 'app'". Move pick_worker into a
module of your own package — one the image adds with
add_local_python_source(...) — and import it into the entry point instead
of defining it there.
```

### The CLI has to report the entry point's name

`find_spec` alone cannot catch this. The CLI inserts the file's directory
into `sys.path` *and* registers the module in `sys.modules`, so
`importlib.util.find_spec("app")` **succeeds** in the deploying process —
twice over. Nothing about the name looks synthetic locally; only the
container knows it is not real. `_cli/modal.py` therefore scopes its
`exec_module` with `_loading_deploy_entrypoint(module_name)`, and
`find_spec` remains only as a weaker second net for a module that does not
resolve even locally. There is a test pinning that, so the reason the
obvious check was not used does not get lost.

### Predicting cloudpickle, not just reading `__module__`

Measured against `modal._vendor.cloudpickle`, with the entry point loaded
exactly as the CLI loads it:

| callable in the entry point | serialized as | needs `app` in the container? |
| --- | --- | --- |
| module-level `def` | `STACK_GLOBAL app.<name>` | **yes — fatal** |
| instance of a class defined there | `STACK_GLOBAL app.<Class>` + reconstruct | **yes — fatal** |
| `functools.partial` of a module-level `def` | partial by value, wrapping `app.<name>` | **yes — fatal** |
| module-level `lambda` | `_make_function` (by value) | no |
| closure returned by a factory | `_make_function` (by value) | no |
| anything in `__main__` | `_make_function` (by value) | no |
| imported from a package module | `STACK_GLOBAL my_pkg.routing.<name>` | no — it is in the image |

Rejecting on `__module__` alone would be wrong in both directions: it
would refuse lambdas and closures that work today, and it would miss a
`functools.partial` (whose own `__module__` is `functools`) and a callable
instance (whose reference is its class). So the check resolves the
`(module, qualname)` cloudpickle would actually write, looking through
`partial` and bound methods.

`__main__` is deliberately **not** rejected — cloudpickle refuses to
reference it and falls back to pickling by value, so it is the one
unimportable module that already works. Anything the check cannot decide
is let through, on the same best-effort principle as the arity check next
to it.

## Docs

The placement note lived only on `ContainerSetup`'s docstring, which read
as though the constraint were specific to the hook. It now covers all five
parameters, both protocol docstrings, and the Modal how-to, which gains a
section — "Where to define what you pass to `StardagApp`" — stating the
CLI's import naming explicitly. That is the part no app author can infer
from their own code.

## Release

Prepared for **v0.20.1** (patch): `CHANGELOG.md` entry and a
`RELEASE_NOTES.md` section. The version itself comes from the git tag
(hatch-vcs), so there is nothing to bump in a file.

## Testing

- 17 new tests in `TestSerializedCallablePlacement`: the reproduction at
  the pickle-opcode level, the `find_spec`-resolves-locally trap, all five
  parameters, the instance and `partial` shapes, and the four cases that
  must keep working.
- Full `lib/stardag` suite: 1362 passed. The 23 errors are pre-existing on
  `main` (live-Modal tests and a subprocess deploy needing credentials) —
  same count on a stashed working tree.
- `pre-commit` (prettier, ruff, ruff-format, pyright) clean; `mkdocs build`
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
