### PR TITLE
Demote the reactive task-store miss from ERROR to DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **The reactive scheduler no longer logs an ERROR for a task-store miss it
+  recovers from.** `BuildTaskStore.load_task` logged
+  `... not found in the build task store — cannot (re)schedule it` on every
+  miss, but its only caller rehydrates the task from registry data and
+  succeeds. Declaring `task_modules` _is_ the opt-in to pickle elision, so on
+  the recommended configuration every lookup misses by design: a healthy
+  seven-task build emitted seven errors claiming its tasks could not be
+  scheduled, immediately after which all seven were. The miss is now DEBUG.
+  A store entry that is not a `BaseTask` remains an ERROR, and `_load_task`
+  still logs at ERROR when _both_ stages fail — with the failed-import
+  annotation that makes it actionable.
+
 ## [0.20.1] — 2026-08-28
 
 ### SDK

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -86,12 +86,20 @@ class BuildTaskStore:
             self.save_task(task)
 
     def load_task(self, task_id: UUID | str) -> BaseTask | None:
-        """Load a task by id; None if not persisted (logged as error)."""
+        """Load a task by id; None if not persisted.
+
+        A miss is *not* an error. The store is a fallback (see the module
+        docs): declaring ``task_modules`` opts a build into pickle elision,
+        so every covered task misses here by design and is rehydrated from
+        registry data by ``stardag.build._reactive._load_task``. Only that
+        caller — which knows whether the second stage also failed — is in a
+        position to log the failure, and it does.
+        """
         target = self._target(f"tasks/{task_id}.pkl")
         if not target.exists():
-            logger.error(
-                f"Task {task_id} of build {self.build_id} not found in the "
-                f"build task store — cannot (re)schedule it."
+            logger.debug(
+                f"Task {task_id} of build {self.build_id} is not in the "
+                f"build task store (expected when pickles are elided)."
             )
             return None
         with target.open("rb") as handle:

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -7,8 +7,11 @@ broke re-triggering a reactive build on a Modal volume).
 
 from __future__ import annotations
 
+import logging
 import typing
 from uuid import uuid4
+
+import pytest
 
 from stardag.build import BuildTaskStore
 from stardag.target import InMemoryFileTarget
@@ -47,3 +50,19 @@ def test_load_missing_task_returns_none(
     # registry); a never-persisted task id loads as None.
     store = BuildTaskStore(uuid4())
     assert store.load_task(uuid4()) is None
+
+
+def test_load_missing_task_does_not_log_an_error(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    caplog: pytest.LogCaptureFixture,
+):
+    # A miss is the normal path once pickles are elided (declared
+    # `task_modules`), and `_load_task` rehydrates from registry data. Only
+    # that caller can tell a real failure from a routine miss, so the store
+    # must stay quiet — an ERROR here trained readers to ignore the
+    # scheduler's error lines on the recommended configuration.
+    store = BuildTaskStore(uuid4())
+    with caplog.at_level(logging.DEBUG, logger="stardag.build._task_store"):
+        assert store.load_task(uuid4()) is None
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+    assert any(r.levelno == logging.DEBUG for r in caplog.records)

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -59,8 +59,10 @@ def test_load_missing_task_does_not_log_an_error(
     # A miss is the normal path once pickles are elided (declared
     # `task_modules`), and `_load_task` rehydrates from registry data. Only
     # that caller can tell a real failure from a routine miss, so the store
-    # must stay quiet — an ERROR here trained readers to ignore the
-    # scheduler's error lines on the recommended configuration.
+    # must not report one — nothing at WARNING or above. An ERROR here
+    # trained readers to ignore the scheduler's error lines on the
+    # recommended configuration. DEBUG is still expected and asserted: the
+    # miss stays traceable for anyone debugging a rehydration failure.
     store = BuildTaskStore(uuid4())
     with caplog.at_level(logging.DEBUG, logger="stardag.build._task_store"):
         assert store.load_task(uuid4()) is None

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -64,7 +64,13 @@ def test_load_missing_task_does_not_log_an_error(
     # recommended configuration. DEBUG is still expected and asserted: the
     # miss stays traceable for anyone debugging a rehydration failure.
     store = BuildTaskStore(uuid4())
-    with caplog.at_level(logging.DEBUG, logger="stardag.build._task_store"):
+    logger_name = "stardag.build._task_store"
+    with caplog.at_level(logging.DEBUG, logger=logger_name):
         assert store.load_task(uuid4()) is None
-    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
-    assert any(r.levelno == logging.DEBUG for r in caplog.records)
+    # Scoped to the store's own logger: `at_level` raises the level for that
+    # logger only, but `caplog.records` captures whatever any logger emits,
+    # so an unrelated WARNING from the target factory would otherwise fail a
+    # test that is not about it.
+    records = [r for r in caplog.records if r.name == logger_name]
+    assert [r for r in records if r.levelno >= logging.WARNING] == []
+    assert any(r.levelno == logging.DEBUG for r in records)


### PR DESCRIPTION
## Problem

`BuildTaskStore.load_task` logs an ERROR whenever a task's pickle is
absent:

```
ERROR stardag.build._task_store: Task <task-id> of build <build-id> not found in the build task store — cannot (re)schedule it.
```

Its only caller, `_reactive._load_task`, is a **two-stage lookup**: the
store first, then `task_from_registry_data`, then a best-effort
write-back of the rehydrated object. So when the ERROR is emitted,
"cannot (re)schedule it" is not yet true — and on an app that declares
`task_modules` it never is.

Declaring `task_modules` *is* the opt-in to pickle elision
(`elide_pickles = self._task_modules_declared or self.require_pickle_free`),
so the writer deliberately persists no pickle for any task whose class
the declared patterns cover. Every store lookup for those tasks misses
by design, and each one logged an ERROR.

Observed on a healthy reactive build of 7 tasks, all covered by the
declared patterns: 7 × the ERROR above, each immediately followed by
`INFO Rehydrated task <id> from registry data.`, and a terminal
`TickSummary(outcome='terminal', terminal_status='completed',
failed_recorded=0, ...)`. Exactly one ERROR per task, then silence —
`_load_task` writes each rehydrated task back, so later lookups hit.

Cosmetic, but corrosive in a specific way: it teaches readers to ignore
ERROR lines from the scheduler, on the configuration the docs recommend.
The cost lands later, when someone is triaging a real failure in a log
full of errors that never mattered.

## Change

- The miss is now DEBUG, with a message that says what it means rather
  than making a claim the caller has not yet tested.
- The docstring says why the store is not the one to log it: only
  `_load_task` knows whether the second stage also failed.
- Unchanged: the other branch of `load_task` — a store entry that is not
  a `BaseTask` — is a genuine error and stays ERROR; and `_load_task`
  still logs at ERROR when *both* stages fail, with the
  `import_failure_note()` annotation that makes it actionable.
- Regression test asserting a miss emits nothing at WARNING or above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)