### PR TITLE
Ship the working tree, not a version its metadata froze at install time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   `version=` older than the running one — warn rather than refuse, since
   both are something the caller asked for.
 
+  Note that a plain `uv sync` does not refresh a stale editable version:
+  the install is already present, so nothing rebuilds its metadata.
+  `uv sync --reinstall-package stardag` does.
+
 ## [0.20.1] — 2026-08-28
 
 ### SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,34 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   still logs at ERROR when _both_ stages fail — with the failed-import
   annotation that makes it actionable.
 
+- **`with_stardag_on_image` no longer pins a Modal image to a stale PyPI
+  release when stardag is installed editable.** The choice between "ship
+  the local working tree" and "install the pinned release" was inferred
+  from `stardag.__version__` — but that is
+  `importlib.metadata.version("stardag")`, and an **editable install's
+  metadata version is a snapshot taken when the install ran**. hatch-vcs
+  computes it from the git tag reachable at that moment and nothing
+  recomputes it as the working tree moves on, so a checkout installed at
+  v0.17.0 keeps reporting `0.17.0` while its source is v0.20.x. That string
+  carries no `dev` and no `+`, so it read as a plain released version and
+  the image was pinned to a real PyPI release **older than the code being
+  serialized into it**.
+
+  The result is the failure shape v0.20.1's placement guardrail was built
+  for, from a different cause: the app deploys cleanly and then every
+  container dies at hydration with `ModuleNotFoundError` for a stardag
+  module the deploying process could see and the container cannot —
+  observed as `No module named 'stardag.integration.modal._builder'`,
+  before any of the app's own code runs.
+
+  `local_stardag_source="auto"` now asks the installer whether this is a
+  working tree (an editable install, a bare `sys.path` entry, or a dev
+  version) instead of guessing from the version string. The two routes that
+  can still pin a version older than the running source — an explicit
+  `local_stardag_source="no"` from a working tree, and an explicit
+  `version=` older than the running one — warn rather than refuse, since
+  both are something the caller asked for.
+
 ## [0.20.1] — 2026-08-28
 
 ### SDK

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1198,8 +1198,13 @@ warn:
 - An explicit `with_stardag_on_image(image, version=...)` older than the
   stardag you are deploying with.
 
-If you hit this after upgrading a stardag checkout, reinstalling it
-(`uv sync`) refreshes the recorded version.
+If you hit this in a stardag checkout, note that a plain `uv sync` will
+**not** refresh the recorded version — the editable install is already
+present, so nothing rebuilds its metadata. Force it:
+
+```bash
+uv sync --reinstall-package stardag
+```
 
 ## Container setup: code that runs in every container
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1177,6 +1177,30 @@ code object by value. They work — but a lambda that _calls_ a `def` from
 the same file drags the same broken reference along with it, so importing
 from a real module is the habit worth keeping.
 
+### The same failure from the other direction: stardag's own version
+
+Cloudpickle stores **stardag's** callables by reference too, so the image's
+stardag has to be at least as new as the stardag doing the pickling. If it
+is older, the app deploys cleanly and every container dies at hydration on
+a stardag module — `No module named 'stardag.integration.modal._builder'`,
+say — instead of one of yours.
+
+`with_stardag_on_image` handles this for you: it ships your **local working
+tree** when stardag is installed editable or is a dev build, and installs
+the pinned release otherwise. Two things can still get it wrong, and both
+warn:
+
+- `STARDAG_MODAL_LOCAL_STARDAG_SOURCE=no` while you are working in a
+  stardag checkout. The version it then pins comes from the install
+  metadata, and an **editable install's version is frozen at install
+  time** — a checkout installed at `0.17.0` reports `0.17.0` however far
+  its source has moved on.
+- An explicit `with_stardag_on_image(image, version=...)` older than the
+  stardag you are deploying with.
+
+If you hit this after upgrading a stardag checkout, reinstalling it
+(`uv sync`) refreshes the recorded version.
+
 ## Container setup: code that runs in every container
 
 Some setup is a property of the _container_, not of a build or a task:

--- a/lib/stardag/src/stardag/integration/modal/_config.py
+++ b/lib/stardag/src/stardag/integration/modal/_config.py
@@ -52,12 +52,13 @@ def _running_from_editable_install() -> bool:
     ``importlib.metadata.version("stardag")``, and an editable install's
     metadata version is a **snapshot taken when the install ran**. hatch-vcs
     computes it from the git tag reachable at that moment and nothing
-    recomputes it as the working tree moves on, so a checkout installed at
-    v0.17.0 keeps reporting ``0.17.0`` while its source is v0.20.x. That
-    string carries no ``dev`` and no ``+``, so it read as a plain released
-    version — and the image was pinned to a **real PyPI release that
-    predates the source being pickled into it**. See
-    :func:`with_stardag_on_image` for what that does.
+    recomputes it as the working tree moves on — not even a plain
+    ``uv sync``, which sees the editable install already present and leaves
+    its metadata alone. So a checkout installed at v0.17.0 keeps reporting
+    ``0.17.0`` while its source is v0.20.x. That string carries no ``dev``
+    and no ``+``, so it read as a plain released version — and the image was
+    pinned to a **real PyPI release that predates the source being pickled
+    into it**. See :func:`with_stardag_on_image` for what that does.
 
     ``PackageNotFoundError`` means stardag is importable but not installed
     at all (a bare ``sys.path`` entry), which is a working tree by any other
@@ -141,7 +142,10 @@ def with_stardag_on_image(
             "serialized into this app's functions, in which case the app "
             "deploys cleanly and every container then fails to hydrate. "
             "Set STARDAG_MODAL_LOCAL_STARDAG_SOURCE=yes to ship the working "
-            "tree instead, or reinstall stardag to refresh its version.",
+            "tree instead, or refresh the recorded version (a plain "
+            "`uv sync` will not: the install is already there, so nothing "
+            "rebuilds its metadata — use "
+            "`uv sync --reinstall-package stardag`).",
             pinned_version,
         )
     elif pinned_version != running_version:

--- a/lib/stardag/src/stardag/integration/modal/_config.py
+++ b/lib/stardag/src/stardag/integration/modal/_config.py
@@ -71,10 +71,21 @@ def _running_from_editable_install() -> bool:
     if not direct_url:
         return False
     try:
-        return bool(json.loads(direct_url).get("dir_info", {}).get("editable"))
+        editable = json.loads(direct_url).get("dir_info", {}).get("editable")
     except (ValueError, AttributeError):
-        # Malformed record: not evidence of an editable install.
+        # Unreadable record: nothing to go on, so not evidence of an
+        # editable install.
         return False
+    # PEP 610 says this is a boolean and every installer writes one. A value
+    # that is not — a string, a number, some future spelling — is read
+    # leniently: anything truthy counts as editable. The two mistakes are
+    # not symmetric. Guessing "editable" wrongly ships the working tree into
+    # the image, and if that image then lacks a dependency the container
+    # fails on its first import, loudly and immediately. Guessing "released"
+    # wrongly pins a version nothing has checked, which is the
+    # deploy-clean-then-die-at-hydration failure this function exists to
+    # prevent.
+    return bool(editable)
 
 
 def with_stardag_on_image(
@@ -165,12 +176,18 @@ def with_stardag_on_image(
             pinned_version,
         )
     elif pinned_version != running_version:
+        # Fires on any difference, not only an older pin: ordering two
+        # versions properly needs PEP 440, and `packaging` is not a stardag
+        # dependency — taking one on to refine the trigger of a warning is a
+        # poor trade. The message names the dangerous direction instead, so
+        # a newer pin reads as the note it is rather than as an alarm.
         logger.warning(
             "Installing stardag==%s from PyPI into a Modal image while "
             "running %s. Functions registered by StardagApp are serialized "
-            "and reference stardag's own modules by name, so a pinned "
-            "version older than the running one can leave every container "
-            "unable to hydrate.",
+            "and reference stardag's own modules by name, so if the pinned "
+            "version is the *older* of the two, every container can fail to "
+            "hydrate on a module it does not have. Pinning a newer version "
+            "does not cause that.",
             pinned_version,
             running_version,
         )

--- a/lib/stardag/src/stardag/integration/modal/_config.py
+++ b/lib/stardag/src/stardag/integration/modal/_config.py
@@ -1,3 +1,6 @@
+import json
+import logging
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Literal
 
@@ -8,12 +11,19 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 import stardag as sd
 from stardag.utils.resource_provider import resource_provider
 
+logger = logging.getLogger(__name__)
+
 
 class ModalConfig(BaseSettings):
     """Configuration of the modal integration."""
 
     volume_mounts: dict[str, str] = {}  # path -> volume name
 
+    # Where a Modal image gets stardag from: the local working tree, or
+    # PyPI. ``auto`` ships the working tree when stardag is running from
+    # one (an editable install, or a dev build) and installs the pinned
+    # release otherwise. See :func:`with_stardag_on_image` for why the
+    # choice matters more than it looks.
     local_stardag_source: Literal["yes", "no", "auto"] = "auto"
 
     model_config = SettingsConfigDict(
@@ -30,34 +40,121 @@ class ModalConfig(BaseSettings):
 modal_config_provider = resource_provider(ModalConfig, ModalConfig)
 
 
+def _running_from_editable_install() -> bool:
+    """Whether the imported ``stardag`` is an editable (or bare source) install.
+
+    This is the question ``local_stardag_source="auto"`` actually wants
+    answered — "am I running stardag from a working tree?" — and it is
+    answerable directly, from the installer's own record.
+
+    It used to be inferred from the version string instead, which is wrong
+    for exactly this case: ``stardag.__version__`` is
+    ``importlib.metadata.version("stardag")``, and an editable install's
+    metadata version is a **snapshot taken when the install ran**. hatch-vcs
+    computes it from the git tag reachable at that moment and nothing
+    recomputes it as the working tree moves on, so a checkout installed at
+    v0.17.0 keeps reporting ``0.17.0`` while its source is v0.20.x. That
+    string carries no ``dev`` and no ``+``, so it read as a plain released
+    version — and the image was pinned to a **real PyPI release that
+    predates the source being pickled into it**. See
+    :func:`with_stardag_on_image` for what that does.
+
+    ``PackageNotFoundError`` means stardag is importable but not installed
+    at all (a bare ``sys.path`` entry), which is a working tree by any other
+    name and wants the same treatment.
+    """
+    try:
+        direct_url = distribution("stardag").read_text("direct_url.json")
+    except PackageNotFoundError:
+        return True
+    if not direct_url:
+        return False
+    try:
+        return bool(json.loads(direct_url).get("dir_info", {}).get("editable"))
+    except (ValueError, AttributeError):
+        # Malformed record: not evidence of an editable install.
+        return False
+
+
 def with_stardag_on_image(
     image: modal.Image,
     version: str | None = None,
 ) -> modal.Image:
-    """Install the latest version of stardag from PyPI into the given Modal image.
+    """Make stardag available in the given Modal image.
+
+    Two ways, chosen by ``ModalConfig.local_stardag_source``
+    (``STARDAG_MODAL_LOCAL_STARDAG_SOURCE``):
+
+    - **From PyPI**, pinned to the running version. The default for an
+      ordinary installed stardag.
+    - **From the local working tree**, via ``add_local_python_source``, plus
+      stardag's own dependencies from its ``pyproject.toml``. The default
+      when stardag is installed editable or is a dev build — i.e. when you
+      are developing stardag itself.
+
+    Getting that choice wrong is not a slow path, it is a broken deploy.
+    ``StardagApp.finalize`` registers ``serialized=True`` functions, and
+    cloudpickle writes stardag's own callables out as *references* to their
+    defining modules. If the image's stardag is older than the source that
+    did the pickling, the app deploys cleanly and then every container dies
+    at hydration with ``ModuleNotFoundError`` for a module the deploying
+    process could see and the container cannot — before any of the app's own
+    code runs. Which is why ``auto`` asks the installer whether this is a
+    working tree (see :func:`_running_from_editable_install`) rather than
+    guessing from a version string that an editable install freezes at
+    install time.
 
     Args:
         image: The Modal image to install stardag into.
-        version: The version of stardag to install. If None, installs the latest
-            version.
+        version: Pin the PyPI install to this version instead of the running
+            one. Ignored when the local source is used. Pinning a version
+            **older than the running source** reintroduces the failure above,
+            so it is warned about.
     Returns:
         The updated Modal image.
     """
-    version = version or sd.__version__
-    # if on a dev version: "0.1.1.dev3+g389c509a7"
-    is_dev_version = "dev" in version or "+" in version
-    # if we are on a dev version, install from local source
+    running_version = sd.__version__
+    pinned_version = version or running_version
+    # A dev build's version says so: "0.1.1.dev3+g389c509a7".
+    is_dev_version = "dev" in running_version or "+" in running_version
     local_stardag_source = modal_config_provider.get().local_stardag_source
 
-    use_local_stardag_source = (
-        is_dev_version and local_stardag_source != "no"
-    ) or local_stardag_source == "yes"
+    from_working_tree = is_dev_version or _running_from_editable_install()
+    use_local_stardag_source = local_stardag_source == "yes" or (
+        local_stardag_source == "auto" and from_working_tree
+    )
 
     if use_local_stardag_source:
         sd_deps = _get_stardag_deps_for_image(include_dev_deps=False)
         return image.pip_install(*sd_deps).add_local_python_source("stardag")
-    else:
-        return image.pip_install(f"stardag[modal]=={version}")
+
+    # Pinning to PyPI. Say so when the pin cannot be trusted to match the
+    # source about to be pickled into this image — a warning rather than a
+    # refusal, because both routes here are something the caller asked for
+    # explicitly, and the pinned release may well be the right one.
+    if from_working_tree:
+        logger.warning(
+            "Installing stardag==%s from PyPI into a Modal image while "
+            "running stardag from a working tree. The version is read from "
+            "the install metadata, which an editable install freezes at "
+            "install time — so it may be older than the code being "
+            "serialized into this app's functions, in which case the app "
+            "deploys cleanly and every container then fails to hydrate. "
+            "Set STARDAG_MODAL_LOCAL_STARDAG_SOURCE=yes to ship the working "
+            "tree instead, or reinstall stardag to refresh its version.",
+            pinned_version,
+        )
+    elif pinned_version != running_version:
+        logger.warning(
+            "Installing stardag==%s from PyPI into a Modal image while "
+            "running %s. Functions registered by StardagApp are serialized "
+            "and reference stardag's own modules by name, so a pinned "
+            "version older than the running one can leave every container "
+            "unable to hydrate.",
+            pinned_version,
+            running_version,
+        )
+    return image.pip_install(f"stardag[modal]=={pinned_version}")
 
 
 def _get_stardag_deps_for_image(include_dev_deps: bool = False) -> list[str]:

--- a/lib/stardag/src/stardag/integration/modal/_config.py
+++ b/lib/stardag/src/stardag/integration/modal/_config.py
@@ -109,12 +109,15 @@ def with_stardag_on_image(
         image: The Modal image to install stardag into.
         version: Pin the PyPI install to this version instead of the running
             one. Ignored when the local source is used. Pinning a version
-            **older than the running source** reintroduces the failure above,
-            so it is warned about.
+            **older than the source doing the pickling** reintroduces the
+            failure above, so it is warned about — and warned about
+            differently from a working tree, where there is no trustworthy
+            running version to compare the pin against at all.
     Returns:
         The updated Modal image.
     """
     running_version = sd.__version__
+    explicitly_pinned = bool(version)
     pinned_version = version or running_version
     # A dev build's version says so: "0.1.1.dev3+g389c509a7".
     is_dev_version = "dev" in running_version or "+" in running_version
@@ -133,10 +136,23 @@ def with_stardag_on_image(
     # source about to be pickled into this image — a warning rather than a
     # refusal, because both routes here are something the caller asked for
     # explicitly, and the pinned release may well be the right one.
-    if from_working_tree:
+    if from_working_tree and explicitly_pinned:
+        logger.warning(
+            "Pinning stardag==%s from PyPI into a Modal image while running "
+            "stardag from a working tree. There is no version to check that "
+            "pin against — an editable install's recorded version is frozen "
+            "at install time, so the tree's real version is unknown — and if "
+            "the pin is older than the code being serialized into this app's "
+            "functions, the app deploys cleanly and every container then "
+            "fails to hydrate. Drop the `version=` argument and set "
+            "STARDAG_MODAL_LOCAL_STARDAG_SOURCE=yes to ship the working tree "
+            "instead.",
+            pinned_version,
+        )
+    elif from_working_tree:
         logger.warning(
             "Installing stardag==%s from PyPI into a Modal image while "
-            "running stardag from a working tree. The version is read from "
+            "running stardag from a working tree. That version is read from "
             "the install metadata, which an editable install freezes at "
             "install time — so it may be older than the code being "
             "serialized into this app's functions, in which case the app "

--- a/lib/stardag/tests/test_integration/test_modal/test__config.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__config.py
@@ -404,7 +404,38 @@ class TestWithStardagOnImage:
             with_stardag_on_image(mock_image)
 
         mock_image.pip_install.assert_called_once_with("stardag[modal]==0.17.0")
-        assert "freezes at install time" in caplog.text
+        assert "read from the install metadata" in caplog.text
+        assert "uv sync --reinstall-package stardag" in caplog.text
+
+    def test_explicit_pin_from_a_working_tree_warns_about_the_pin(self, caplog) -> None:
+        """Same route, but the version came from the caller, not from the
+        install metadata — so the metadata explanation would be the wrong
+        one to give. What is true here is that there is nothing to check the
+        pin against: a working tree's real version is unknown."""
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            patch(
+                "stardag.integration.modal._config._running_from_editable_install",
+                return_value=True,
+            ),
+            patch.object(
+                modal_config_provider,
+                "get",
+                return_value=ModalConfig(local_stardag_source="no"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_sd.__version__ = "0.17.0"
+
+            with_stardag_on_image(mock_image, version="0.19.0")
+
+        mock_image.pip_install.assert_called_once_with("stardag[modal]==0.19.0")
+        assert "no version to check that pin against" in caplog.text
+        # Not the metadata story: the pinned version did not come from there.
+        assert "read from the install metadata" not in caplog.text
 
     def test_pinning_an_older_version_than_the_running_one_warns(
         self, not_editable, caplog

--- a/lib/stardag/tests/test_integration/test_modal/test__config.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__config.py
@@ -303,9 +303,22 @@ class TestRunningFromEditableInstall:
         ):
             assert _running_from_editable_install() is True
 
-    def test_malformed_record_is_not_evidence(self) -> None:
+    def test_unreadable_record_is_not_evidence(self) -> None:
         with self._with_direct_url("not json at all"):
             assert _running_from_editable_install() is False
+
+    def test_a_readable_but_odd_editable_value_is_read_leniently(self) -> None:
+        """PEP 610 says `editable` is a boolean and every installer writes
+        one, so this is hypothetical — but the two ways of being wrong are
+        not symmetric, and the lenient one is the one that fails loudly.
+
+        Guessing "editable" wrongly ships the working tree, and a missing
+        dependency then breaks the first import. Guessing "released"
+        wrongly pins a version nothing checked — the silent
+        deploy-clean-then-die failure this whole change is about.
+        """
+        with self._with_direct_url('{"dir_info": {"editable": "yes"}}'):
+            assert _running_from_editable_install() is True
 
 
 class TestWithStardagOnImage:
@@ -454,7 +467,29 @@ class TestWithStardagOnImage:
             with_stardag_on_image(mock_image, version="0.17.0")
 
         mock_image.pip_install.assert_called_once_with("stardag[modal]==0.17.0")
-        assert "unable to hydrate" in caplog.text
+        assert "the *older* of the two" in caplog.text
+
+    def test_a_newer_pin_warns_but_names_the_harmless_direction(
+        self, not_editable, caplog
+    ) -> None:
+        """Pinning *newer* than the running SDK cannot cause the hydration
+        failure — the image would have more modules, not fewer. Ordering
+        two versions properly needs PEP 440 and `packaging` is not a
+        stardag dependency, so the warning still fires on any difference
+        and the message carries the direction instead."""
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_sd.__version__ = "0.17.0"
+
+            with_stardag_on_image(mock_image, version="0.20.1")
+
+        mock_image.pip_install.assert_called_once_with("stardag[modal]==0.20.1")
+        assert "Pinning a newer version does not cause that" in caplog.text
 
     def test_matching_pin_is_quiet(self, not_editable, caplog) -> None:
         mock_image = MagicMock(spec=modal.Image)

--- a/lib/stardag/tests/test_integration/test_modal/test__config.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__config.py
@@ -1,5 +1,7 @@
 """Tests for stardag.integration.modal._config module."""
 
+import logging
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +15,7 @@ except ImportError:
 from stardag.integration.modal._config import (
     ModalConfig,
     _get_stardag_deps_for_image,
+    _running_from_editable_install,
     get_package_deps,
     modal_config_provider,
     with_stardag_on_image,
@@ -241,10 +244,74 @@ class TestGetStardagDepsForImage:
         assert deps == []
 
 
+@pytest.fixture
+def not_editable():
+    """Pretend the running stardag is an ordinary (non-editable) install.
+
+    The test suite itself runs from an editable checkout, so without this
+    every ``with_stardag_on_image`` case would take the local-source
+    branch — which is the whole point of the check, and not what most of
+    these tests are about.
+    """
+    with patch(
+        "stardag.integration.modal._config._running_from_editable_install",
+        return_value=False,
+    ):
+        yield
+
+
+class TestRunningFromEditableInstall:
+    """Whether stardag is running from a working tree.
+
+    The answer decides whether a Modal image gets stardag from PyPI or from
+    the local source, and getting it wrong deploys an app whose containers
+    all die at hydration — see ``with_stardag_on_image``.
+    """
+
+    def _with_direct_url(self, direct_url: str | None):
+        dist = MagicMock()
+        dist.read_text.return_value = direct_url
+        return patch(
+            "stardag.integration.modal._config.distribution", return_value=dist
+        )
+
+    def test_editable_install_is_a_working_tree(self) -> None:
+        with self._with_direct_url(
+            '{"url": "file:///repo/lib/stardag", "dir_info": {"editable": true}}'
+        ):
+            assert _running_from_editable_install() is True
+
+    def test_ordinary_wheel_install_is_not(self) -> None:
+        """No ``direct_url.json`` at all: installed from an index."""
+        with self._with_direct_url(None):
+            assert _running_from_editable_install() is False
+
+    def test_non_editable_local_install_is_not(self) -> None:
+        """``pip install .`` records a direct URL but is a real snapshot of
+        the source, not a live view of it."""
+        with self._with_direct_url(
+            '{"url": "file:///repo/lib/stardag", "dir_info": {}}'
+        ):
+            assert _running_from_editable_install() is False
+
+    def test_not_installed_at_all_is_a_working_tree(self) -> None:
+        """Importable off a bare ``sys.path`` entry — a working tree by any
+        other name, and it has no version metadata to trust either."""
+        with patch(
+            "stardag.integration.modal._config.distribution",
+            side_effect=PackageNotFoundError("stardag"),
+        ):
+            assert _running_from_editable_install() is True
+
+    def test_malformed_record_is_not_evidence(self) -> None:
+        with self._with_direct_url("not json at all"):
+            assert _running_from_editable_install() is False
+
+
 class TestWithStardagOnImage:
     """Tests for with_stardag_on_image function."""
 
-    def test_uses_pypi_for_release_version(self) -> None:
+    def test_uses_pypi_for_release_version(self, not_editable) -> None:
         """Test it installs from PyPI for release versions."""
         mock_image = MagicMock(spec=modal.Image)
         mock_image.pip_install.return_value = mock_image
@@ -257,15 +324,120 @@ class TestWithStardagOnImage:
         mock_image.pip_install.assert_called_once_with("stardag[modal]==1.0.0")
         assert result == mock_image
 
-    def test_uses_pypi_with_explicit_version(self) -> None:
+    def test_uses_pypi_with_explicit_version(self, not_editable) -> None:
         """Test it uses explicit version when provided."""
         mock_image = MagicMock(spec=modal.Image)
         mock_image.pip_install.return_value = mock_image
 
-        result = with_stardag_on_image(mock_image, version="2.0.0")
+        with patch("stardag.integration.modal._config.sd") as mock_sd:
+            mock_sd.__version__ = "2.0.0"
+
+            result = with_stardag_on_image(mock_image, version="2.0.0")
 
         mock_image.pip_install.assert_called_once_with("stardag[modal]==2.0.0")
         assert result == mock_image
+
+    def test_editable_install_uses_local_source_despite_a_release_version(
+        self,
+    ) -> None:
+        """The regression this exists for.
+
+        An editable install's metadata version is a snapshot taken when the
+        install ran, so a checkout installed at 0.17.0 keeps reporting
+        ``0.17.0`` while its source moves on. That string looks like a plain
+        release, so the image used to be pinned to a **real PyPI release
+        older than the code being serialized into it** — the app deployed
+        cleanly and every container then died at hydration with
+        ``ModuleNotFoundError`` for a stardag module the deploying process
+        could see and the container could not.
+        """
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+        mock_image.add_local_python_source.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            patch(
+                "stardag.integration.modal._config._running_from_editable_install",
+                return_value=True,
+            ),
+            patch.object(
+                modal_config_provider,
+                "get",
+                return_value=ModalConfig(local_stardag_source="auto"),
+            ),
+            patch(
+                "stardag.integration.modal._config._get_stardag_deps_for_image",
+                return_value=["pydantic>=2.0"],
+            ),
+        ):
+            mock_sd.__version__ = "0.17.0"  # stale metadata, looks released
+
+            result = with_stardag_on_image(mock_image)
+
+        mock_image.add_local_python_source.assert_called_once_with("stardag")
+        mock_image.pip_install.assert_called_once_with("pydantic>=2.0")
+        assert result == mock_image
+
+    def test_pypi_from_a_working_tree_warns(self, caplog) -> None:
+        """``local_stardag_source="no"`` from an editable checkout is the
+        one route left to the broken deploy. It is the caller's explicit
+        choice, so it is honoured — and said out loud."""
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            patch(
+                "stardag.integration.modal._config._running_from_editable_install",
+                return_value=True,
+            ),
+            patch.object(
+                modal_config_provider,
+                "get",
+                return_value=ModalConfig(local_stardag_source="no"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_sd.__version__ = "0.17.0"
+
+            with_stardag_on_image(mock_image)
+
+        mock_image.pip_install.assert_called_once_with("stardag[modal]==0.17.0")
+        assert "freezes at install time" in caplog.text
+
+    def test_pinning_an_older_version_than_the_running_one_warns(
+        self, not_editable, caplog
+    ) -> None:
+        """Same failure, reached explicitly: the pinned release predates the
+        source doing the pickling."""
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_sd.__version__ = "0.20.1"
+
+            with_stardag_on_image(mock_image, version="0.17.0")
+
+        mock_image.pip_install.assert_called_once_with("stardag[modal]==0.17.0")
+        assert "unable to hydrate" in caplog.text
+
+    def test_matching_pin_is_quiet(self, not_editable, caplog) -> None:
+        mock_image = MagicMock(spec=modal.Image)
+        mock_image.pip_install.return_value = mock_image
+
+        with (
+            patch("stardag.integration.modal._config.sd") as mock_sd,
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_sd.__version__ = "0.20.1"
+
+            with_stardag_on_image(mock_image, version="0.20.1")
+
+        assert caplog.text == ""
 
     def test_uses_local_source_for_dev_version(self) -> None:
         """Test it uses local source for dev versions (containing 'dev')."""


### PR DESCRIPTION
A deployed app whose containers all died at hydration:

```
ModuleNotFoundError: No module named 'stardag.integration.modal._builder'
modal.exception.DeserializationError: Deserialization failed because the
'stardag.integration.modal._builder' module is not available in the remote
environment.
```

Also `._runner`, and for the same reason — several modules missing at once.

## Root cause

`with_stardag_on_image` chose between "ship the local working tree" and
"install the pinned release" by looking for `dev` or `+` in
`stardag.__version__`. That value is `importlib.metadata.version("stardag")`
— **install metadata** — and for an editable install it is a snapshot taken
when the install ran: hatch-vcs computes it from the git tag reachable at
that moment and nothing recomputes it as the tree moves on. Not even a
plain `uv sync`, which sees the editable install already present and leaves
its metadata alone.

So a checkout installed at v0.17.0 keeps reporting `0.17.0` while its source
is v0.20.x. That string carries no `dev` and no `+`, so it read as a plain
released version, and the image was pinned to a **real PyPI release that
predates the source being pickled into it**. `0.17.0` is older than the
`_app.py` split, hence `_builder` and `_runner` both missing.

This is the failure shape #277's placement guardrail was built for, reached
from the opposite direction: there the module was un-importable everywhere,
here it is importable in the deploying process and absent in the container.
Either way the app deploys cleanly, prints its full function list, and then
every container dies before any of the app's own code runs.

**Why it stayed latent.** It only bites once the working tree grows a module
the pinned release lacks. An editable install made at v0.17.0 was fine until
`_builder` landed, and every deploy from that checkout has been broken since.

## The fix

`local_stardag_source="auto"` now asks the installer whether this is a
working tree — `direct_url.json`'s `dir_info.editable` — which is the
question it was trying to answer all along. A missing distribution counts
too: importable but not installed is a working tree by any other name, and
it has no version metadata to trust either. The dev-version check stays
alongside it, since a non-editable install of a dev build is still a dev
build.

Two routes can still pin something older than the running source, and both
are the caller saying so explicitly:

- `local_stardag_source="no"` from a working tree;
- an explicit `with_stardag_on_image(image, version=...)` older than the
  running version.

Those warn rather than refuse — pinning an older SDK deliberately is a
legitimate thing to want.

## The remedy, verified rather than assumed

A plain `uv sync` in an already-synced checkout reports no change and leaves
the metadata at `0.17.0`. `uv sync --reinstall-package stardag` rebuilds it.
Documenting "reinstall it" without that flag would send a reader round the
loop they are already in, so the flag is in the warning text, the docs and
the changelog.

## Tests

Five for the editable detection (editable install, plain wheel, non-editable
local install, not installed at all, malformed record) and four for the
resulting choice — including a regression test named for the `0.17.0` case,
and one asserting a matching pin stays quiet.

Two existing tests needed a fixture: the suite itself runs from an editable
checkout, so without pinning the check they would now take the local-source
branch. That they failed before the fixture was added is the bug reproducing
itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
