### PR TITLE
Stop recommending the watchdog; the default is the right answer

### DIFF
--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -321,7 +321,8 @@ app = StardagApp(
     "my-app",
     builder_settings=FunctionSettings(image=image),
     worker_settings={"default": FunctionSettings(image=image)},
-    watchdog_period_minutes=5,          # recommended with reactive mode
+    watchdog_period_minutes=5,          # off by default; only when a
+                                        # stalled build must self-heal fast
     limit_key_selector=lambda t: [],    # named concurrency-limit keys per task
     container_setup=my_container_setup, # runs once in EVERY container
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **The Modal watchdog is no longer recommended by default.**
+  `watchdog_period_minutes` has always defaulted to off, but the docs,
+  examples and a trigger-time warning all pushed towards `=5`. The sweep
+  runs on its schedule whether or not anything is building, and that steady
+  polling is enough to keep a scale-to-zero registry database awake — a
+  bill that never shows up as Modal usage. It also matters less than it
+  did: the reactive exit handshake closes the lost-wake-up window the
+  watchdog was mostly guarding.
+
+  The guidance is now "leave it off, and turn it on when leaving a build
+  stalled for even a few minutes is unacceptable — then pick the period
+  from how long that is". Named concurrency limits remain the clearest
+  reason to enable it, since a slot freed in another build has nothing to
+  notify this one. **`build_trigger(reactive=True)` no longer warns** when
+  no watchdog is configured: it fired on the recommended configuration.
+
 - **The reactive scheduler no longer logs an ERROR for a task-store miss it
   recovers from.** `BuildTaskStore.load_task` logged
   `... not found in the build task store — cannot (re)schedule it` on every

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -406,9 +406,11 @@ two cases from the frontier's list of blocking upstreams this build does
 not own:
 
 - **A RUNNING blocker whose execution claim is still live** — the build
-  waits, exactly as it waits for a busy concurrency-limit slot. The
-  blocker's completion wakes this scheduler, and the watchdog covers a lost
-  wake-up.
+  waits, exactly as it waits for a busy concurrency-limit slot. Note that
+  **nothing pushes the blocker's completion to this build**: a build only
+  ever wakes itself, so this wait is ended by the watchdog, by a task of
+  this build's own finishing, or by a tick you spawn. Cross-build waiting
+  is the case for enabling `watchdog_period_minutes`.
 - **A RUNNING blocker whose execution claim has lapsed** — the build fails.
   Not "presumed abandoned": the claim's expiry has passed, so the registry
   no longer honours it, has stopped counting it against concurrency limits,

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -434,8 +434,8 @@ orchestrator at all**. The trigger mints the build, registers the root
 tasks and spawns one deployed function — `bootstrap` — with those roots
 passed by value; everything else is driven by short-lived scheduler
 _ticks_, spawned by the bootstrap, when a worker finishes a task and no
-scheduler is already live to notice, and (recommended) by a periodic
-watchdog. Between ticks, nothing runs except your tasks: a multi-day build
+scheduler is already live to notice, and — if you turn it on — by a
+periodic watchdog. Between ticks, nothing runs except your tasks: a multi-day build
 with a few long-running tasks costs no orchestrator container time, and
 there is no orchestrator process whose crash could affect the build.
 
@@ -463,9 +463,6 @@ app = sd_modal.StardagApp(
     "stardag-poc",
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={"default": sd_modal.FunctionSettings(image=image)},
-    # Recommended with reactive mode: periodically re-check running builds
-    # (covers lost wake-ups and builds cancelled from the UI).
-    watchdog_period_minutes=5,
 )
 
 # After deploy:
@@ -518,7 +515,6 @@ app = sd_modal.StardagApp(
     tick_settings=sd_modal.FunctionSettings(image=image, timeout=300),
     # Discovery of a very wide DAG gets its own budget.
     bootstrap_settings=sd_modal.FunctionSettings(image=image, timeout=1800),
-    watchdog_period_minutes=5,
 )
 ```
 
@@ -554,16 +550,29 @@ Two operational notes:
   Declaring [`task_modules`](#declaring-your-task-modules-recommended) is
   what makes "still importable" true by construction — and lets stardag
   skip the pickle in the first place.
-- **The watchdog sweep runs one quick scheduling pass per running build
-  that this app owns** (it skips the linger), so its per-period cost is
-  one short function invocation plus a frontier query per such build.
-  The sweep asks the registry only for RUNNING builds whose reactive
-  owner is this app, so unrelated builds in the environment — resident
-  builds, and builds left RUNNING by an orchestrator that died without
-  emitting a terminal event — cost nothing and cannot crowd out the
-  sweep's per-period cap. A build owned by an app deployed _without_
-  `watchdog_period_minutes` therefore has no watchdog covering it, even
-  if another app in the environment has one.
+- **The watchdog is off by default, and that is usually right.** It only
+  catches what nothing else reports — a silently dead worker, a build
+  cancelled in the UI, a concurrency slot freed by another build — and a
+  stalled build is unblocked by a single tick, which you can spawn at any
+  time by re-triggering the build id. Turn it on
+  (`watchdog_period_minutes=…`) when leaving a build stalled for even a few
+  minutes is unacceptable, and pick the period from how long that is.
+
+  The reason not to leave it on "just in case" is that the sweep runs on
+  its schedule whether or not anything is building, and its steady polling
+  is enough to keep a scale-to-zero registry database awake — a bill that
+  does not show up as Modal usage.
+
+  Each sweep runs one quick scheduling pass per running build that this app
+  owns (it skips the linger), so its per-period cost is one short function
+  invocation plus a frontier query per such build. The sweep asks the
+  registry only for RUNNING builds whose reactive owner is this app, so
+  unrelated builds in the environment — resident builds, and builds left
+  RUNNING by an orchestrator that died without emitting a terminal event —
+  cost nothing and cannot crowd out the sweep's per-period cap. A build
+  owned by an app deployed _without_ `watchdog_period_minutes` has no
+  watchdog covering it, even if another app in the environment has one.
+
 - **Define the callables you pass to `StardagApp` in an importable
   module.** `worker_selector`, `limit_key_selector`, and any custom
   build/run functions are captured by the serialized Modal functions
@@ -616,7 +625,6 @@ app = sd_modal.StardagApp(
     "stardag-poc",
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={"default": sd_modal.FunctionSettings(image=image)},
-    watchdog_period_minutes=5,
     # Modules whose import registers the task classes this app may
     # schedule. Default: the root package of the module defining the app.
     # Pass [] to opt out (resident builds never need this).
@@ -720,7 +728,6 @@ app = sd_modal.StardagApp(
     "stardag-poc",
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={"default": sd_modal.FunctionSettings(image=image)},
-    watchdog_period_minutes=5,
     limit_key_selector=lambda task: ["gpu"] if needs_gpu(task) else [],
 )
 ```
@@ -729,12 +736,15 @@ A task denied by a limit stays pending and is retried when a slot frees
 (immediately for same-build releases; within the watchdog period for
 releases in other builds).
 
-When limits are enforced, **the watchdog is strongly recommended**
-(`watchdog_period_minutes=5`): a slot is freed by the holder reaching a
-terminal status, and the watchdog is the safety net that keeps statuses
-honest when wake-ups are lost — including the escape hatch that fails a
-task stuck RUNNING without an execution ref once its **execution claim
-lapses** (see below), which would otherwise hold its slots indefinitely.
+Limits are the clearest case for turning the **watchdog** on
+(`watchdog_period_minutes=…`, off by default — see
+[Reactive scheduling](#reactive-scheduling-no-resident-build-function-experimental)):
+a slot freed in _another_ build
+has nothing to notify this one, and the watchdog is also the escape hatch
+that fails a task stuck RUNNING without an execution ref once its
+**execution claim lapses** (see below), which would otherwise hold its
+slots indefinitely. Weigh that against how long a stalled slot actually
+costs you.
 Also note that limit-key tags recorded at a
 task's start persist until its next start _with_ keys — a later build
 re-running the same task id without tags briefly counts under the old
@@ -1058,7 +1068,6 @@ app = sd_modal.StardagApp(
         "default": sd_modal.FunctionSettings(image=image, timeout=3600)
     },
     tick_settings=sd_modal.FunctionSettings(image=image, timeout=600),
-    watchdog_period_minutes=5,
 )
 ```
 
@@ -1238,7 +1247,6 @@ app = sd_modal.StardagApp(
     container_setup=container_setup,
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={"default": sd_modal.FunctionSettings(image=image)},
-    watchdog_period_minutes=5,
 )
 ```
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -736,15 +736,14 @@ A task denied by a limit stays pending and is retried when a slot frees
 (immediately for same-build releases; within the watchdog period for
 releases in other builds).
 
-Limits are the clearest case for turning the **watchdog** on
-(`watchdog_period_minutes=…`, off by default — see
+Limits make the **watchdog** load-bearing (`watchdog_period_minutes=…`,
+off by default — see
 [Reactive scheduling](#reactive-scheduling-no-resident-build-function-experimental)):
-a slot freed in _another_ build
-has nothing to notify this one, and the watchdog is also the escape hatch
-that fails a task stuck RUNNING without an execution ref once its
+a slot freed in _another_ build has nothing to notify this one, so the
+watchdog period is how long a denied task waits. It is also the escape
+hatch that fails a task stuck RUNNING without an execution ref once its
 **execution claim lapses** (see below), which would otherwise hold its
-slots indefinitely. Weigh that against how long a stalled slot actually
-costs you.
+slots indefinitely.
 Also note that limit-key tags recorded at a
 task's start persist until its next start _with_ keys — a later build
 re-running the same task id without tags briefly counts under the old

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/app.py
@@ -41,7 +41,8 @@ app = sd_modal.StardagApp(
     # Nothing to configure for the interruption behaviour: the task asks
     # to be resumed by raising sd.ResumableInterruption, and the scheduler
     # obliges up to TickConfig.max_interruptions (default 20).
-    # Reactive scheduling is what resumes the task, and the watchdog is the
-    # backstop if a wake-up is ever lost.
-    watchdog_period_minutes=5,
+    # Reactive scheduling is what resumes the task. No watchdog: it is off
+    # by default and nothing here needs one — a stalled build is unblocked
+    # by re-triggering the build id, and a permanent sweep is a standing
+    # cost (see the Modal how-to).
 )

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/README.md
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/README.md
@@ -30,8 +30,9 @@ Report
   build function resumes the same registry build.
 - **two workers + `worker_selector`** — `LongScan` runs on a `long` worker
   with a higher timeout.
-- **`watchdog_period_minutes=5`** — scheduled safety-net ticks for
-  reactive builds (lost wake-ups, UI cancellations, stale limit slots).
+- **`watchdog_period_minutes=5`** — scheduled safety-net ticks. Off by
+  default; on here because named limits are used, and a slot freed in
+  another build has nothing to notify this one.
 - **`limit_key_selector`** — tags every `ProcessShard` with the
   `walkthrough-shards` named limit. The cap itself is configured in the
   registry (next section).

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
@@ -12,9 +12,11 @@ full (new) feature set:
   name. Configured on the app (not per trigger) so reactive scheduler
   ticks apply the same routing.
 - ``watchdog_period_minutes``: a scheduled function that periodically
-  re-ticks running reactive builds — the safety net for lost wake-ups,
-  builds cancelled from the UI, and stale concurrency-limit slots.
-  Strongly recommended whenever reactive mode or named limits are used.
+  re-ticks running reactive builds. **Off by default**, and enabled here
+  for the reason that justifies it: this app uses named limits, and a slot
+  freed in another build has nothing to notify this one. Leaving it on
+  without such a reason costs a scheduled sweep forever — see the Modal
+  how-to.
 - ``limit_key_selector``: tags every ``ProcessShard`` task with the
   ``SHARD_LIMIT_KEY`` named concurrency limit. The cap itself lives in
   the registry, per environment — see ``configure_limits.py``. Like the
@@ -85,8 +87,8 @@ app = sd_modal.StardagApp(
         "long": sd_modal.FunctionSettings(image=image, cpu=1, timeout=1800),
     },
     worker_selector=worker_selector,
-    # Reactive-mode safety net: periodically re-check running builds
-    # (lost wake-ups, UI cancellations, stale limit slots).
+    # Off by default; on here because this app uses named limits and a
+    # slot freed in another build has nothing to notify this one.
     watchdog_period_minutes=5,
     limit_key_selector=limit_key_selector,
 )

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -450,10 +450,23 @@ class StardagApp:
                 (see that argument). Discovery there runs against whatever
                 the triggering process is already configured with.
             watchdog_period_minutes: If set, register a scheduled watchdog
-                that periodically re-ticks running reactive builds (the
-                safety net for lost wake-ups, UI-cancelled builds, and stale
-                concurrency-limit slots). Strongly recommended when using
-                ``build_trigger(reactive=True)``. Default: no watchdog.
+                that periodically re-ticks running reactive builds — a
+                safety net for the rare cases nothing else reports: a
+                silently dead worker, a build cancelled in the UI, a
+                concurrency slot freed by another build.
+
+                Default (``None``, no watchdog) is the right choice for
+                most apps. The sweep runs on a schedule whether or not
+                anything is building, and its steady polling is enough to
+                keep a scale-to-zero registry database awake — a cost that
+                does not show up as Modal usage. When a build does stall,
+                one tick unblocks it, and a tick can be spawned at any time
+                (re-trigger the build id, or invoke the app's deployed
+                ``tick`` function directly).
+
+                Set it when leaving a build stalled for even a few minutes
+                is unacceptable, and pick the period from how long that is
+                — not from a default.
             limit_key_selector: Maps a task to the named registry
                 concurrency-limit keys it runs under in reactive scheduling
                 (deployed-app configuration applied by every tick). Default:
@@ -1241,15 +1254,6 @@ class StardagApp:
             )
 
         if reactive:
-            if self.watchdog_period_minutes is None:
-                logger.warning(
-                    "Reactive build triggered on an app without a watchdog "
-                    "(watchdog_period_minutes is not set): a lost wake-up "
-                    "(e.g. a silently dead worker, or a tick killed while "
-                    "holding the scheduler lease) can stall the build until "
-                    "it is manually re-triggered. Strongly recommended: "
-                    "StardagApp(watchdog_period_minutes=5)."
-                )
             return self._trigger_reactive(
                 task_list,
                 build_id=build_id,

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -811,7 +811,7 @@ class TestStardagAppReactiveTrigger:
         registry = MagicMock(spec=RegistryABC)
         registry.build_start.return_value = _uuid4()
 
-        with caplog.at_level(logging.WARNING, logger="stardag.integration.modal"):
+        with caplog.at_level(logging.WARNING, logger="stardag.integration.modal._app"):
             _trigger_reactive(
                 app,
                 SyncOnlyTask(name="no-watchdog-root"),

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import importlib.util
+import logging
 import io
 import pickletools
 import sys
@@ -785,6 +786,42 @@ class TestStardagAppReactiveTrigger:
             "test-reactive-app",
             builder_settings=FunctionSettings(image=_make_image()),
             worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+
+    def test_no_watchdog_is_not_worth_warning_about(
+        self, modal_function_stub, default_in_memory_fs_target, caplog
+    ):
+        """``watchdog_period_minutes=None`` is the default *and* the
+        recommendation, so triggering without one must be silent.
+
+        This used to warn on every reactive trigger, urging
+        ``watchdog_period_minutes=5``. A warning that fires on the
+        recommended configuration is how people learn to ignore warnings,
+        and the sweep it was urging is a standing cost — it polls on its
+        schedule whether or not anything is building, which is enough to
+        keep a scale-to-zero registry database awake. Guidance now lives on
+        the parameter's docstring; this pins the silence.
+        """
+        from uuid import uuid4 as _uuid4
+
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = self._make_app()
+        assert app.watchdog_period_minutes is None
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = _uuid4()
+
+        with caplog.at_level(logging.WARNING, logger="stardag.integration.modal"):
+            _trigger_reactive(
+                app,
+                SyncOnlyTask(name="no-watchdog-root"),
+                stub=modal_function_stub,
+                registry=registry,
+                run_bootstrap=False,
+            )
+
+        assert "watchdog" not in caplog.text.lower(), (
+            f"reactive trigger warned about the absent watchdog again: {caplog.text}"
         )
 
     def test_trigger_spawns_bootstrap_with_the_roots_by_value(


### PR DESCRIPTION
`watchdog_period_minutes` has always defaulted to off, but everything around it pushed towards `=5`: the Modal how-to called it "recommended" and carried it in six examples that were not teaching it, the walkthrough called it *strongly* recommended, and `build_trigger(reactive=True)` **warned whenever it was absent** — a warning that fired on the recommended configuration, which is how people learn to ignore warnings.

## Why the default is the better answer

**The cost is real and invisible.** The sweep runs on its schedule whether or not anything is building, and that steady polling is enough to keep a scale-to-zero registry database awake. It never shows up as Modal usage — it appears on the database bill. A 5-minute period against a serverless Postgres means the compute never idles down; on a free tier of 100 CU-hrs (roughly four days of one always-on CU) an otherwise *idle* deployment exhausts the month in days and takes the registry down with it.

**And it matters less than it did.** The reactive exit handshake closes the lost-wake-up window the watchdog was mostly guarding. What is left is what nothing else reports: a silently dead worker, a build cancelled in the UI, a concurrency slot freed by another build.

**A stalled build is cheap to unblock.** One tick does it, and a tick can be spawned at any time by re-triggering the build id.

## The new guidance

> Leave it off. Turn it on when leaving a build stalled for even a few minutes is unacceptable — and pick the period from how long that is, not from a default.

Named concurrency limits stay the clearest reason to enable it, since a slot freed in *another* build has nothing to notify this one. That case is now stated as a condition rather than a blanket recommendation.

## Changes

- **`build_trigger(reactive=True)` no longer warns** when no watchdog is configured. The `watchdog_period_minutes` docstring carries the guidance instead, where someone deciding will read it.
- **How-to:** the watchdog line comes out of five examples that were teaching something else (`task_modules`, `limit_key_selector`, spawn caps, `container_setup`, the tuned deployment). The sweep bullet that was already there becomes where the guidance lives, keeping its cost detail. The limits section keeps its recommendation but as an evaluable condition.
- **Examples:** the walkthrough keeps its watchdog — it uses named limits, which is exactly the reason — now stated as such. `checkpointing` loses one it had no reason for.

Mostly deletions and rewrites rather than a new section: **+83 / −50** across 7 files.

## Note

The trigger-time warning is the only behaviour change; no test pinned it. Suites green (1384 SDK). `lib/stardag-examples` tests do not collect in this checkout — its venv has stardag 0.11.0 and `task_modules` already fails to import on `main` — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
