### PR TITLE
Prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-08-29
+
 ### SDK
 
 - **The reactive scheduler no longer logs an ERROR for a task-store miss it

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -70,44 +70,6 @@ Nothing to change. Two notes if you have written against the internals:
   while handing off on the way out belongs to whoever holds the lease. It
   warns once per process if the lease is taken without one.
 
-### A build no longer waits on news it will never hear
-
-Separate bug, same area, found while verifying the above. Reactive builds
-run only while one of their ticks does, and a worker notifies the build it
-belongs to. So when build A finished a task build B was blocked on,
-**nothing told B** — it waited for the watchdog, which is off by default,
-or for one of its own tasks to finish, of which a blocked build may have
-none.
-
-Finishing a task now flags every other live build holding it, and the
-worker that finished it spawns their ticks. A build owned by a **different
-app** is reached too. Again the registry has to be new enough: an older one
-reports nothing to wake, and those builds wait for the watchdog as before.
-
-**One cross-build wait is still not pushed:** a named concurrency-limit
-slot released by another build. The builds queued on a key are not the
-builds holding the task that occupies it, and the registry does not yet
-know which keys a _pending_ task wants. That wait still ends at the
-watchdog.
-
-### The watchdog is no longer recommended by default
-
-`watchdog_period_minutes` has always defaulted to off, but the docs,
-examples and a trigger-time warning all pushed towards `=5`. The sweep runs
-on its schedule whether or not anything is building, and that steady
-polling is enough to keep a scale-to-zero registry database awake — a bill
-that never shows up as Modal usage.
-
-It also matters less than it did, for both reasons above: the exit
-handshake closes the lost-wake-up window, and cross-build waits on a shared
-task are now pushed. What is left is a silently dead worker, a build
-cancelled in the UI, and a concurrency-limit slot freed by another build —
-the last being the one clear reason to turn it on.
-
-**`build_trigger(reactive=True)` no longer warns** when no watchdog is
-configured. It fired on the recommended configuration, which is how people
-learn to ignore warnings.
-
 ### Also in this release
 
 - **`with_stardag_on_image` no longer pins a Modal image to a stale PyPI

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,8 @@ registry:
 | Doing the work   | 1 (`iterations=7, spawned=7`) | 1 (`iterations=7, spawned=7`) |
 | Doing nothing    | **7**                         | **0**                         |
 
+Both numbers are from a live run, not an estimate.
+
 ### The correctness fix underneath it
 
 Skipping the spawn is only safe if a live scheduler cannot exit past a
@@ -67,6 +69,44 @@ Nothing to change. Two notes if you have written against the internals:
   two halves belong together: the worker decides on what the registry says,
   while handing off on the way out belongs to whoever holds the lease. It
   warns once per process if the lease is taken without one.
+
+### A build no longer waits on news it will never hear
+
+Separate bug, same area, found while verifying the above. Reactive builds
+run only while one of their ticks does, and a worker notifies the build it
+belongs to. So when build A finished a task build B was blocked on,
+**nothing told B** — it waited for the watchdog, which is off by default,
+or for one of its own tasks to finish, of which a blocked build may have
+none.
+
+Finishing a task now flags every other live build holding it, and the
+worker that finished it spawns their ticks. A build owned by a **different
+app** is reached too. Again the registry has to be new enough: an older one
+reports nothing to wake, and those builds wait for the watchdog as before.
+
+**One cross-build wait is still not pushed:** a named concurrency-limit
+slot released by another build. The builds queued on a key are not the
+builds holding the task that occupies it, and the registry does not yet
+know which keys a _pending_ task wants. That wait still ends at the
+watchdog.
+
+### The watchdog is no longer recommended by default
+
+`watchdog_period_minutes` has always defaulted to off, but the docs,
+examples and a trigger-time warning all pushed towards `=5`. The sweep runs
+on its schedule whether or not anything is building, and that steady
+polling is enough to keep a scale-to-zero registry database awake — a bill
+that never shows up as Modal usage.
+
+It also matters less than it did, for both reasons above: the exit
+handshake closes the lost-wake-up window, and cross-build waits on a shared
+task are now pushed. What is left is a silently dead worker, a build
+cancelled in the UI, and a concurrency-limit slot freed by another build —
+the last being the one clear reason to turn it on.
+
+**`build_trigger(reactive=True)` no longer warns** when no watchdog is
+configured. It fired on the recommended configuration, which is how people
+learn to ignore warnings.
 
 ### Also in this release
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,92 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.21.0 — One scheduler tick per build, not one per finished task
+
+Additive for anyone using the Modal integration as documented. The
+behaviour change is that a finishing worker now **skips spawning a
+scheduler tick when the registry says one is already live** — fewer
+containers, same scheduling.
+
+**Upgrade the registry (stardag-api) too, or you get the old behaviour.**
+The "is a scheduler live?" answer comes from the server. An older registry
+does not send it, the SDK reads that as "unknown", and every wake-up spawns
+a tick exactly as before — correct, just not cheaper. Nothing breaks either
+way, and the two can be upgraded in any order.
+
+### What it fixes
+
+On a build whose tasks are short relative to a tick container's startup,
+every completion used to spawn a tick that did nothing. The resident
+scheduler's own linger loop did all the work; each spawned tick started
+after it, found the lease held or the build already terminal, and exited.
+
+Measured end-to-end on a 7-task build, before and after, same DAG and same
+registry:
+
+|                  | before                        | after                         |
+| ---------------- | ----------------------------- | ----------------------------- |
+| Tick invocations | **8**                         | **1**                         |
+| Doing the work   | 1 (`iterations=7, spawned=7`) | 1 (`iterations=7, spawned=7`) |
+| Doing nothing    | **7**                         | **0**                         |
+
+### The correctness fix underneath it
+
+Skipping the spawn is only safe if a live scheduler cannot exit past a
+wake-up it has not seen — and the old exit path could. Nothing re-read the
+wake-up flag between the linger loop's final poll and the release of the
+scheduler lease, so a flag set in that window was served by nobody until
+the next completion or the watchdog. With the last task in flight there may
+be no next completion.
+
+A tick now re-reads the flag once **before** releasing the lease (set →
+keep the lease and re-act) and once **after** (set → spawn a successor
+tick). This closes the release window; it is not crash recovery — a tick
+that clears the flag and then dies still leaves that wake-up to the next
+completion or the watchdog, as before.
+
+Two new `TickSummary` counters, `linger_extended` and `successor_spawned`,
+report each half. Both are normally zero: the window they cover is rare by
+construction.
+
+### Migration
+
+Nothing to change. Two notes if you have written against the internals:
+
+- **`RegistryABC.build_notify` now returns `BuildNotifyResult`** instead of
+  `None`. A custom backend that overrides it and returns `None` keeps
+  working — that reads as "scheduler state unknown", which spawns.
+- **A custom tick runner** (anything calling `run_tick_aio` directly rather
+  than through the Modal integration) should pass
+  `TickConfig.spawn_successor_tick` if its workers can skip spawning. The
+  two halves belong together: the worker decides on what the registry says,
+  while handing off on the way out belongs to whoever holds the lease. It
+  warns once per process if the lease is taken without one.
+
+### Also in this release
+
+- **`with_stardag_on_image` no longer pins a Modal image to a stale PyPI
+  release when stardag is installed editable.** The choice between shipping
+  the working tree and installing the pinned release was inferred from the
+  version string, but an editable install's recorded version is frozen at
+  install time — a checkout installed at v0.17.0 keeps reporting `0.17.0`
+  while its source moves on. The image was then pinned to a real release
+  older than the code being serialized into it, and every container died at
+  hydration with `ModuleNotFoundError` for a stardag module. It now asks the
+  installer whether this is a working tree.
+
+  If you deploy from a stardag checkout and see this, note that a plain
+  `uv sync` does not refresh the recorded version — `uv sync
+--reinstall-package stardag` does.
+
+- **The reactive scheduler no longer logs an ERROR for a task-store miss it
+  recovers from.** Declaring `task_modules` _is_ the opt-in to pickle
+  elision, so on the recommended configuration every lookup missed by
+  design and a healthy build emitted one error per task. The miss is now
+  DEBUG.
+
+---
+
 ## v0.20.1 — A callable your containers cannot import is now refused at deploy
 
 Nearly additive. The one behaviour change: `StardagApp(...)` raises

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,8 +83,8 @@ Nothing to change. Two notes if you have written against the internals:
   installer whether this is a working tree.
 
   If you deploy from a stardag checkout and see this, note that a plain
-  `uv sync` does not refresh the recorded version — `uv sync
---reinstall-package stardag` does.
+  `uv sync` does not refresh the recorded version;
+  `uv sync --reinstall-package stardag` does.
 
 - **The reactive scheduler no longer logs an ERROR for a task-store miss it
   recovers from.** Declaring `task_modules` _is_ the opt-in to pickle


### PR DESCRIPTION
Prepares **v0.21.0**. Changelog heading and release notes only — no code. The version comes from the git tag via hatch-vcs, so there is nothing to bump.

**Do not merge until the two items under "Before merging" are settled.**

## Why minor, not patch

- `RegistryABC.build_notify` returns `BuildNotifyResult` instead of `None`
- `TickConfig` gains `spawn_successor_tick`; `TickSummary` gains `linger_extended` and `successor_spawned`
- the registry API gains a response field on `POST /builds/{id}/notify`

Nothing breaks. A custom backend still returning `None` from `build_notify` reads as "scheduler state unknown", which spawns — the old behaviour.

## What is in it

| PR | |
| --- | --- |
| #280 | Conditional wake-ups + the exit handshake that makes them safe |
| #281 | `with_stardag_on_image` no longer pins an image to a stale PyPI release from an editable install |
| (direct) | Task-store miss demoted from ERROR to DEBUG |

## Verified end-to-end

The N+1 → 1 claim is measured, not inferred. Same DAG, same registry, same database; only the DAG app's SDK differs.

| | before (`84024348`) | after (`d979264f`) |
| --- | --- | --- |
| Tick invocations | **8** | **1** |
| Doing the work | 1 (`iterations=7, spawned=7`) | 1 (`iterations=7, spawned=7`) |
| Doing nothing | **7** (`lease_held`) | **0** |
| Build result | completed | completed |

The "after" tick's stored summary carries 25 fields including `linger_extended` and `successor_spawned`, against the control's 23 — which is how we know the measured tick was running the merged code rather than a container left warm from the previous deployment. A first attempt at this measurement *was* contaminated that way and was discarded.

## The one thing a reader will get wrong

The "is a scheduler live?" answer comes from the **server**. An SDK on 0.21.0 against an older registry gets no answer, reads it as unknown, and spawns a tick per wake-up exactly as before. Correct, just not cheaper. The release notes lead with this because it is the difference between "the feature does nothing" and "the feature is broken", and it is the former.

## Resolved before marking ready

1. **#282 was folded into #284 and closed; #284 went back to draft after review and is being redesigned** (STA-12). Neither the cross-build wake-up nor the watchdog-docs change is in this release. The release notes were trimmed accordingly in `c693a725` — the changelog never carried either.
2. Release date is 2026-08-29 in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


