### PR TITLE
Read the wake-up flag from its own row, not from the whole frontier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,25 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git tag
   only.
 
+- **The linger poll no longer reads the frontier.**
+  `RegistryABC.build_get_notify[_aio]` reads the wake-up flag, and the tick's
+  linger poll, its pre-release re-check and its exit hand-off all use it. The
+  frontier is fetched only when there is something to act on. Against a
+  server without the route the poll falls back to the frontier read it did
+  before — latched once per process, since re-probing on every poll is the
+  cost the endpoint removes. The default implementation on `RegistryABC`
+  delegates to the frontier, so a custom backend needs no changes to keep
+  working, and can override for the cheap read.
+
+### Registry API
+
+- **`GET /builds/{build_id}/notify`** reads a build's scheduler wake-up flag
+  from its own row, with nothing derived. The reactive tick's linger poll
+  asks one question every few seconds per lingering build — "has anything
+  changed?" — and used to ask it by fetching the whole frontier: five
+  queries including two window-function aggregates over the event log, of
+  which it read a single boolean.
+
 ### Deployment
 
 - **Server image `0.2.0`**, the first server release since `0.1.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   linger poll, its pre-release re-check and its exit hand-off all use it. The
   frontier is fetched only when there is something to act on. Against a
   server without the route the poll falls back to the frontier read it did
-  before — latched once per process, since re-probing on every poll is the
-  cost the endpoint removes. The default implementation on `RegistryABC`
+  before, and an unparseable answer reads as _unset_ rather than set —
+  fabricating a change would spin the tick without releasing its lease.
+  Latched once per process, since re-probing on every poll is the cost the
+  endpoint removes. The default implementation on `RegistryABC`
   delegates to the frontier, so a custom backend needs no changes to keep
   working, and can override for the cheap read.
 
@@ -101,9 +103,9 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 - **`GET /builds/{build_id}/notify`** reads a build's scheduler wake-up flag
   from its own row, with nothing derived. The reactive tick's linger poll
   asks one question every few seconds per lingering build — "has anything
-  changed?" — and used to ask it by fetching the whole frontier: five
-  queries including two window-function aggregates over the event log, of
-  which it read a single boolean.
+  changed?" — and used to ask it by fetching the whole frontier: seven
+  statements, one of them a window-function aggregate over the event log,
+  of which it read a single boolean.
 
 ### Deployment
 

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1627,6 +1627,31 @@ async def notify_build(
     )
 
 
+@router.get("/{build_id}/notify", response_model=BuildNotifyResponse)
+async def read_build_notify(
+    build_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+):
+    """Read the build's scheduler wake-up flag. One row, nothing derived.
+
+    A lingering tick asks one question every few seconds — "has anything
+    changed?" — and used to ask it by fetching the whole frontier: five
+    queries including two window-function aggregates over the event log, of
+    which it read a single boolean. This is that boolean.
+
+    ``scheduler_live`` is deliberately not answered here, and its absence is
+    not a version signal. The caller is the tick that *holds* the lease, so
+    the answer would only ever be "yourself"; computing it would cost the
+    second table this endpoint exists to avoid.
+    """
+    _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
+    build = await _get_build_checked(build_id, db, auth)
+    return BuildNotifyResponse(
+        build_id=build_id, needs_tick=build.needs_tick_at is not None
+    )
+
+
 @router.delete("/{build_id}/notify", response_model=BuildNotifyResponse)
 async def clear_build_notify(
     build_id: UUID,

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1636,9 +1636,9 @@ async def read_build_notify(
     """Read the build's scheduler wake-up flag. One row, nothing derived.
 
     A lingering tick asks one question every few seconds — "has anything
-    changed?" — and used to ask it by fetching the whole frontier: five
-    queries including two window-function aggregates over the event log, of
-    which it read a single boolean. This is that boolean.
+    changed?" — and used to ask it by fetching the whole frontier: seven
+    statements, one of them a window-function aggregate over the event log,
+    of which it read a single boolean. This is that boolean.
 
     ``scheduler_live`` is deliberately not answered here, and its absence is
     not a version signal. The caller is the tick that *holds* the lease, so

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -709,10 +709,12 @@ class BuildNotifyResponse(BaseModel):
     # is what pins it to that side of the write; a separate query invites
     # the opposite ordering.
     #
-    # None on DELETE (the clearing caller *is* the scheduler, so it has no
-    # use for the answer), and read by the SDK as "unknown" — which it also
-    # is on any server predating this field, and which falls back to
-    # spawning unconditionally.
+    # Answered only on POST. None on DELETE and on GET — in both cases the
+    # caller *is* the scheduler (it holds the lease it would be asking
+    # about), so the answer would be its own reflection, and computing it
+    # would cost the second table the GET exists to avoid. Read by the SDK
+    # as "unknown", which it also is on any server predating this field,
+    # and which falls back to spawning unconditionally.
     scheduler_live: bool | None = None
 
 

--- a/app/stardag-api/tests/test_wakeups.py
+++ b/app/stardag-api/tests/test_wakeups.py
@@ -591,3 +591,64 @@ async def test_bulk_registration_flags_nobody(client: AsyncClient):
 
     assert await _needs_tick(client, a) is False
     assert await _needs_tick(client, b) is False
+# --- GET /builds/{id}/notify: the linger poll's one-row read (STA-18) ----
+
+
+async def test_reading_the_flag_agrees_with_the_frontier(client: AsyncClient):
+    """The whole point is that it is the *same* boolean, more cheaply.
+
+    A second source of truth for "does this build need a tick" would be
+    worse than the frontier read it replaces, so the two are asserted
+    together rather than separately.
+    """
+    build_id, other_id = await _shared(client)
+    await _clear(client, build_id, other_id)
+
+    assert (await client.get(f"/api/v1/builds/{build_id}/notify")).json()[
+        "needs_tick"
+    ] is False
+    assert await _needs_tick(client, build_id) is False
+
+    await client.post(f"/api/v1/builds/{build_id}/notify")
+
+    assert (await client.get(f"/api/v1/builds/{build_id}/notify")).json()[
+        "needs_tick"
+    ] is True
+    assert await _needs_tick(client, build_id) is True
+
+
+async def test_reading_the_flag_does_not_set_or_clear_it(client: AsyncClient):
+    """A GET is a read. The linger poll calls it every few seconds while
+    the tick still holds the lease; a read with a side effect on the flag
+    would either wake the build forever or swallow a wake-up."""
+    build_id = await _build(client)
+    await client.post(f"/api/v1/builds/{build_id}/notify")
+
+    for _ in range(3):
+        assert (await client.get(f"/api/v1/builds/{build_id}/notify")).json()[
+            "needs_tick"
+        ] is True
+
+    await client.delete(f"/api/v1/builds/{build_id}/notify")
+    for _ in range(3):
+        assert (await client.get(f"/api/v1/builds/{build_id}/notify")).json()[
+            "needs_tick"
+        ] is False
+
+
+async def test_reading_the_flag_reports_no_scheduler_liveness(client: AsyncClient):
+    """``scheduler_live`` is absent by design, not by omission: the caller
+    holds the lease, so the answer would only ever be itself — and computing
+    it costs the second table this endpoint exists to avoid. It must not be
+    reported as ``False``, which a caller reads as "nobody is scheduling"."""
+    build_id = await _build(client)
+    await _hold_lease(client, build_id)
+
+    body = (await client.get(f"/api/v1/builds/{build_id}/notify")).json()
+
+    assert body["scheduler_live"] is None
+
+
+async def test_reading_the_flag_of_an_unknown_build_is_404(client: AsyncClient):
+    response = await client.get(f"/api/v1/builds/{uuid.uuid4()}/notify")
+    assert response.status_code == 404

--- a/app/stardag-api/tests/test_wakeups.py
+++ b/app/stardag-api/tests/test_wakeups.py
@@ -591,6 +591,8 @@ async def test_bulk_registration_flags_nobody(client: AsyncClient):
 
     assert await _needs_tick(client, a) is False
     assert await _needs_tick(client, b) is False
+
+
 # --- GET /builds/{id}/notify: the linger poll's one-row read (STA-18) ----
 
 

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -956,6 +956,13 @@ async def _hand_off_if_needed(
         # common case is an unset flag, which now costs one row instead of
         # a frontier. Deliberately not the slim ``build_get`` — this path
         # asks nothing of a backend that the pre-STA-18 code did not.
+        #
+        # The trade is honest rather than free. When the flag *is* set —
+        # the case this exists for — it is two round trips where it used to
+        # be one; and against a backend on the ABC default, or a server old
+        # enough to have latched the fallback, the flag read *is* a
+        # frontier fetch, so it is two frontier reads. This runs once per
+        # tick, on the way out, so the poll's saving dominates either way.
         info = await registry.build_get_frontier_aio(build_id)
         if info.reactive_app_name is None:
             # Cannot happen for a build this tick just drove — the marker

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -949,10 +949,15 @@ async def _hand_off_if_needed(
     if spawn is None:
         return
     try:
-        flag = await registry.build_get_frontier_aio(build_id)
+        flag = await registry.build_get_notify_aio(build_id)
         if not flag.needs_tick:
             return
-        if flag.reactive_app_name is None:
+        # The frontier read stays here, but only past the flag check: the
+        # common case is an unset flag, which now costs one row instead of
+        # a frontier. Deliberately not the slim ``build_get`` — this path
+        # asks nothing of a backend that the pre-STA-18 code did not.
+        info = await registry.build_get_frontier_aio(build_id)
+        if info.reactive_app_name is None:
             # Cannot happen for a build this tick just drove — the marker
             # never flips back — but the spawner needs an app to reach, and
             # guessing one would be worse than leaving the flag for the
@@ -963,7 +968,7 @@ async def _hand_off_if_needed(
         # (the lease is released, its renewal task cancelled, nothing else
         # is in flight), and requiring an async spawner would exclude the
         # integrations that only have a blocking one.
-        spawn(build_id, flag.reactive_app_name)
+        spawn(build_id, info.reactive_app_name)
         summary.successor_spawned += 1
         logger.info(
             "Build %s was notified while this tick released the scheduler "
@@ -1396,7 +1401,7 @@ async def _run_tick_body_aio(
                             # happen anyway.
                             if config.linger_seconds <= 0:
                                 return
-                            flag = await registry.build_get_frontier_aio(build_id)
+                            flag = await registry.build_get_notify_aio(build_id)
                             if not flag.needs_tick:
                                 return
                             summary.linger_extended += 1
@@ -1413,7 +1418,7 @@ async def _run_tick_body_aio(
                             awaiting_backend, task_executor
                         ):
                             break  # a ref resolved — re-act and pick it up
-                        flag = await registry.build_get_frontier_aio(build_id)
+                        flag = await registry.build_get_notify_aio(build_id)
                         if flag.needs_tick:
                             break  # outer loop clears the flag and re-acts
             finally:

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -1590,6 +1590,49 @@ class APIRegistry(RegistryABC):
         except Exception:  # pragma: no cover - defensive
             return BuildNotifyResult(build_id=build_id)
 
+    @staticmethod
+    def _parse_notify_read(build_id: UUID, response: Any) -> BuildNotifyResult:
+        """Parse a *read* of the flag. Unparseable means "no", not "yes".
+
+        Deliberately not :meth:`_parse_notify_response`, whose tolerance
+        defaults ``needs_tick`` to True. That is right for the setter — the
+        flag really was just set, so the answer only refines an
+        optimisation hint — and exactly wrong here, where nothing was set
+        and a fabricated "yes" is a claim that something changed.
+
+        The cost of getting this backwards is not a wasted pass. The linger
+        loop would clear the flag, re-read the frontier, poll, be told
+        "yes" again, and never exit — while holding the build's scheduler
+        lease and renewing it, so nothing else can drive that build for the
+        life of the container. A silent, non-terminating spin, where the
+        pre-endpoint code would have failed loudly on the frontier's
+        required fields.
+
+        Note the trigger is wider than "corrupt": every field of
+        ``BuildNotifyResult`` has a default, so ``{}`` — or a response whose
+        shape drifts — validates cleanly to the model default. Hence an
+        explicit False rather than relying on one.
+        """
+        try:
+            payload = response.json()
+            value = payload["needs_tick"]
+            if not isinstance(value, bool):
+                # Not coerced. ``bool("no")`` is True, and every other read
+                # of a wake-up answer in this codebase insists on a real
+                # bool for the same reason: a truthiness test turns any
+                # unexpected shape into the answer that spins the tick.
+                raise TypeError(f"needs_tick is {type(value).__name__}, not bool")
+            return BuildNotifyResult(build_id=build_id, needs_tick=value)
+        except Exception:
+            logger.warning(
+                "Unparseable wake-up flag for build %s; treating it as unset. "
+                "The build is still reached by its next wake-up or the "
+                "watchdog — claiming a change nobody made would spin this "
+                "tick without ever releasing the scheduler lease.",
+                build_id,
+            )
+            return BuildNotifyResult(build_id=build_id, needs_tick=False)
+
     def build_wake_candidates(self, limit: int = 20) -> list[WakeCandidate]:
         """Hand out flagged reactive builds with no live scheduler."""
         response = self._request(
@@ -1659,7 +1702,7 @@ class APIRegistry(RegistryABC):
             return self._notify_from_frontier(
                 build_id, self.build_get_frontier(build_id)
             )
-        return self._parse_notify_response(build_id, response)
+        return self._parse_notify_read(build_id, response)
 
     async def build_get_notify_aio(self, build_id: UUID) -> BuildNotifyResult:
         """Async version - read the build's scheduler wake-up flag."""
@@ -1680,10 +1723,19 @@ class APIRegistry(RegistryABC):
             return self._notify_from_frontier(
                 build_id, await self.build_get_frontier_aio(build_id)
             )
-        return self._parse_notify_response(build_id, response)
+        return self._parse_notify_read(build_id, response)
 
     @staticmethod
-    def _notify_from_frontier(build_id: UUID, frontier: Any) -> BuildNotifyResult:
+    def _notify_from_frontier(
+        build_id: UUID, frontier: BuildFrontier
+    ) -> BuildNotifyResult:
+        """The flag as the fallback reads it: off the frontier, as before.
+
+        Typed rather than ``Any`` so a rename of ``BuildFrontier.needs_tick``
+        is a type error here. This path only runs against a server without
+        the route, which is the one nothing exercises in practice — so the
+        static check is the only check it gets.
+        """
         return BuildNotifyResult(build_id=build_id, needs_tick=frontier.needs_tick)
 
     def build_clear_notify(self, build_id: UUID) -> None:

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -57,6 +57,39 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+# Latched once per process when the registry answers ``GET
+# /builds/{id}/notify`` with a missing-route error: an older server, where
+# the linger poll goes back to reading the flag off the frontier. Latched
+# rather than re-probed because the poll runs every few seconds for every
+# lingering build, and a doomed request per poll is the exact cost the
+# endpoint was added to remove. (Same shape as ``_wakeups``' route latch.)
+_notify_read_route_missing = False
+
+
+def _latch_notify_read_missing(error: Exception) -> bool:
+    """Whether ``error`` says the server predates ``GET .../notify``.
+
+    Two shapes, because the path itself exists on such a server for POST and
+    DELETE: a router with no GET on it answers **405**, while a server
+    predating the notify endpoints entirely answers the missing-route 404.
+    """
+    global _notify_read_route_missing
+    unsupported = (
+        is_missing_route_error(error)
+        if isinstance(error, NotFoundError)
+        else isinstance(error, APIError) and error.status_code == 405
+    )
+    if unsupported:
+        _notify_read_route_missing = True
+        logger.debug(
+            "Registry API has no GET /builds/{id}/notify; the linger poll "
+            "reads the wake-up flag off the frontier in this process. "
+            "Upgrade stardag-api to make that poll one row."
+        )
+    return unsupported
+
+
 # Retry configuration for transient errors (connection issues, timeouts, etc.)
 # Retries on: TimeoutException, NetworkError (includes ReadError), RemoteProtocolError
 _RETRY_CONFIG = Retry(
@@ -1597,6 +1630,61 @@ class APIRegistry(RegistryABC):
             except Exception:
                 logger.debug("Ignoring malformed wake candidate: %r", row)
         return candidates
+
+    def build_get_notify(self, build_id: UUID) -> BuildNotifyResult:
+        """Read the wake-up flag (``GET /builds/{id}/notify``). One row.
+
+        Falls back to the frontier read against a server that predates the
+        route, which is what this poll used to do. The fallback is latched
+        per process: the route sits under ``/builds/{build_id}/notify``,
+        which such a server *does* serve for POST and DELETE, so the miss
+        comes back as a 405 rather than a 404 — and re-paying for it on
+        every poll of every lingering build is precisely the cost this
+        endpoint exists to remove.
+        """
+        if _notify_read_route_missing:
+            return self._notify_from_frontier(
+                build_id, self.build_get_frontier(build_id)
+            )
+        try:
+            response = self._request(
+                "GET",
+                f"{self.api_url}/api/v1/builds/{build_id}/notify",
+                params=self._get_params(),
+                operation=f"Read notify flag for build {build_id}",
+            )
+        except Exception as e:
+            if not _latch_notify_read_missing(e):
+                raise
+            return self._notify_from_frontier(
+                build_id, self.build_get_frontier(build_id)
+            )
+        return self._parse_notify_response(build_id, response)
+
+    async def build_get_notify_aio(self, build_id: UUID) -> BuildNotifyResult:
+        """Async version - read the build's scheduler wake-up flag."""
+        if _notify_read_route_missing:
+            return self._notify_from_frontier(
+                build_id, await self.build_get_frontier_aio(build_id)
+            )
+        try:
+            response = await self._arequest(
+                "GET",
+                f"{self.api_url}/api/v1/builds/{build_id}/notify",
+                params=self._get_params(),
+                operation=f"Read notify flag for build {build_id}",
+            )
+        except Exception as e:
+            if not _latch_notify_read_missing(e):
+                raise
+            return self._notify_from_frontier(
+                build_id, await self.build_get_frontier_aio(build_id)
+            )
+        return self._parse_notify_response(build_id, response)
+
+    @staticmethod
+    def _notify_from_frontier(build_id: UUID, frontier: Any) -> BuildNotifyResult:
+        return BuildNotifyResult(build_id=build_id, needs_tick=frontier.needs_tick)
 
     def build_clear_notify(self, build_id: UUID) -> None:
         """Clear the build's scheduler wake-up flag."""

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -911,6 +911,33 @@ class RegistryABC(metaclass=abc.ABCMeta):
         """Async version of build_notify."""
         return self.build_notify(build_id, can_spawn=can_spawn)
 
+    def build_get_notify(self, build_id: UUID) -> BuildNotifyResult:
+        """Read the build's scheduler wake-up flag without setting it.
+
+        The linger poll's question, and the cheapest possible answer to it:
+        one boolean, one row. A lingering tick asks it every few seconds and
+        used to ask it by fetching the whole frontier, of which it read this
+        field alone.
+
+        ``scheduler_live`` is not reported — the caller holds the lease, so
+        the answer is always itself.
+
+        Default: read the flag off the frontier, which is where this poll
+        got it before and which every backend that supports reactive
+        scheduling can already answer. Override it with a cheaper read
+        (the API registry does). Deliberately *not* a constant: "always
+        needs a tick" turns the linger loop into a hot loop, and "never"
+        stalls the build until the watchdog — there is no safe direction
+        to default to, only the real answer.
+        """
+        frontier = self.build_get_frontier(build_id)
+        return BuildNotifyResult(build_id=build_id, needs_tick=frontier.needs_tick)
+
+    async def build_get_notify_aio(self, build_id: UUID) -> BuildNotifyResult:
+        """Async version of build_get_notify."""
+        frontier = await self.build_get_frontier_aio(build_id)
+        return BuildNotifyResult(build_id=build_id, needs_tick=frontier.needs_tick)
+
     def build_clear_notify(self, build_id: UUID) -> None:
         """Clear the build's scheduler wake-up flag. Default: no-op."""
         pass

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -924,11 +924,18 @@ class RegistryABC(metaclass=abc.ABCMeta):
 
         Default: read the flag off the frontier, which is where this poll
         got it before and which every backend that supports reactive
-        scheduling can already answer. Override it with a cheaper read
-        (the API registry does). Deliberately *not* a constant: "always
-        needs a tick" turns the linger loop into a hot loop, and "never"
-        stalls the build until the watchdog — there is no safe direction
-        to default to, only the real answer.
+        scheduling can already answer. Deliberately *not* a constant:
+        "always needs a tick" turns the linger loop into a hot loop, and
+        "never" stalls the build until the watchdog — there is no safe
+        direction to default to, only the real answer.
+
+        **Override both this and the async version** to make the poll
+        cheap. Unlike every other ``_aio`` default on this class, which
+        delegates to its sync twin, ``build_get_notify_aio`` goes sideways
+        to ``build_get_frontier_aio`` — delegating to a blocking call on
+        the hot path would stall the event loop. The cost of that choice is
+        that overriding only the sync method here silently has no effect on
+        the path the tick actually takes.
         """
         frontier = self.build_get_frontier(build_id)
         return BuildNotifyResult(build_id=build_id, needs_tick=frontier.needs_tick)

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -582,6 +582,13 @@ class FakeReactiveRegistry(NoOpRegistry):
     async def build_clear_notify_aio(self, build_id):
         self.needs_tick = False
 
+    async def build_get_notify_aio(self, build_id) -> BuildNotifyResult:
+        # The cheap flag read, overridden rather than inherited: the ABC
+        # default delegates to the frontier, and a double that inherits it
+        # cannot tell "read the flag" from "read the frontier" — which is
+        # exactly what the linger poll's cost depends on.
+        return BuildNotifyResult(build_id=build_id, needs_tick=self.needs_tick)
+
     async def build_get_frontier_aio(self, build_id) -> BuildFrontier:
         if self.frontier_error is not None:
             raise self.frontier_error
@@ -4764,6 +4771,66 @@ class TestInterruptedTasks:
         assert "interrupted" in _RETRYABLE_STATUSES
 
 
+class TestLingerPollCost:
+    """A lingering tick with nothing to do must not read the frontier.
+
+    The poll asks one question — "has anything changed?" — every few
+    seconds, per lingering build. It used to ask it by fetching the whole
+    frontier: five queries including two window-function aggregates over the
+    event log, of which it read a single boolean.
+    """
+
+    async def test_linger_poll_reads_the_flag_not_the_frontier(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        (root,) = _chain("poll-cost-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        registry.add_task(
+            str(root.id),
+            status="running",
+            executor="other-backend",
+            executor_ref="job-1",
+        )
+
+        frontier_reads: list[int] = []
+        notify_reads: list[int] = []
+        real_frontier = registry.build_get_frontier_aio
+        real_notify = registry.build_get_notify_aio
+
+        async def counting_frontier(bid):
+            frontier_reads.append(1)
+            return await real_frontier(bid)
+
+        async def counting_notify(bid):
+            notify_reads.append(1)
+            return await real_notify(bid)
+
+        registry.build_get_frontier_aio = counting_frontier  # type: ignore[method-assign]
+        registry.build_get_notify_aio = counting_notify  # type: ignore[method-assign]
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=dataclasses.replace(
+                FAST_TICK, linger_seconds=0.2, poll_interval_seconds=0.02
+            ),
+        )
+
+        assert summary.outcome == "lingered_out"
+        # Several polls happened — otherwise this proves nothing.
+        assert len(notify_reads) >= 3, notify_reads
+        # ...and the frontier was read once, by the pass itself. Not once
+        # per poll. The exact number is the point of the test, so it is
+        # asserted rather than bounded.
+        assert len(frontier_reads) == 1, (
+            f"the linger poll read the frontier {len(frontier_reads) - 1} "
+            "extra time(s); it must ask the one-row flag endpoint"
+        )
+
+
 class TestExitHandshake:
     """The two re-reads that make a *conditional* wake-up safe.
 
@@ -4836,24 +4903,28 @@ class TestExitHandshake:
         )
 
         # Land the wake-up in the gap deterministically. With one poll per
-        # linger (poll interval > linger), the reads are: 1 the pass's own
-        # frontier, 2 the single linger poll, 3 the pre-release re-check.
-        # Setting the flag right after read 2 puts it exactly between the
-        # last poll and the deadline — the gap the re-check exists for.
+        # linger (poll interval > linger), the *flag* reads are: 1 the
+        # single linger poll, 2 the pre-release re-check. Setting the flag
+        # as read 1 answers "no" puts it exactly between the last poll and
+        # the deadline — the gap the re-check exists for.
+        #
+        # These are notify reads, not frontier reads: the linger poll asks
+        # the one-row endpoint now, so hooking the frontier would no longer
+        # land the flag in this window at all.
         reads: list[int] = []
-        real_frontier = registry.build_get_frontier_aio
+        real_notify = registry.build_get_notify_aio
 
-        async def frontier_then_notify(bid):
-            frontier = await real_frontier(bid)
+        async def notify_then_set(bid):
+            result = await real_notify(bid)
             reads.append(1)
-            if len(reads) == 2:
+            if len(reads) == 1:
                 # Complete the target too, so the extended pass reaches a
                 # terminal state instead of lingering out a second time.
                 root.run()
                 registry.needs_tick = True
-            return frontier
+            return result
 
-        registry.build_get_frontier_aio = frontier_then_notify  # type: ignore[method-assign]
+        registry.build_get_notify_aio = notify_then_set  # type: ignore[method-assign]
 
         spawned, spawn = self._spawner()
         summary = await run_tick_aio(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -4776,8 +4776,8 @@ class TestLingerPollCost:
 
     The poll asks one question — "has anything changed?" — every few
     seconds, per lingering build. It used to ask it by fetching the whole
-    frontier: five queries including two window-function aggregates over the
-    event log, of which it read a single boolean.
+    frontier: seven statements, one of them a window-function aggregate over
+    the event log, of which it read a single boolean.
     """
 
     async def test_linger_poll_reads_the_flag_not_the_frontier(

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -7,6 +7,7 @@ import json
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
 from stardag._version import __version__
@@ -18,6 +19,7 @@ from stardag.exceptions import (
 )
 from stardag.registry._api_registry import (
     _GZIP_REQUEST_THRESHOLD_BYTES,
+    APIRegistry,
     _maybe_gzip_json_body,
 )
 from stardag.registry._http_client import SDK_VERSION_HEADER
@@ -1231,23 +1233,87 @@ class TestNotifyReadFallback:
     """
 
     def _registry(self, handler):
-        import asyncio
+        """Swap the *transport*, not the whole client.
 
-        import httpx
-
-        from stardag.registry._api_registry import APIRegistry
-
+        Default headers (auth, SDK version, User-Agent) are configured on
+        the client the SDK builds, so replacing it would leave these tests
+        asserting against a client the SDK never constructs — the reason
+        ``_CapturingRegistry`` gives for the same choice.
+        """
         registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
-        registry._async_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(handler),
-            auth=registry._auth,
-        )
-        registry._async_client_loop = asyncio.get_running_loop()
+        registry.async_client._transport = httpx.MockTransport(handler)
         return registry
 
-    async def test_405_falls_back_to_the_frontier_and_latches(self, monkeypatch):
-        import httpx
+    async def test_the_flag_round_trips_from_the_route(self, monkeypatch):
+        """The happy path, which nothing else covers — and the reason it
+        matters is the latch below: a wrong path or verb yields FastAPI's
+        404, which is indistinguishable from an old server, so a typo would
+        silently read the frontier for the life of the process with every
+        test still green. So assert the method and the path, not just the
+        answer.
+        """
+        from stardag.registry import _api_registry
 
+        monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
+        seen: list[tuple[str, str]] = []
+        answer = {"needs_tick": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append((request.method, request.url.path))
+            return httpx.Response(200, json=answer)
+
+        registry = self._registry(handler)
+        build_id = uuid4()
+
+        assert (await registry.build_get_notify_aio(build_id)).needs_tick is False
+        answer["needs_tick"] = True
+        assert (await registry.build_get_notify_aio(build_id)).needs_tick is True
+
+        assert seen == [
+            ("GET", f"/api/v1/builds/{build_id}/notify"),
+            ("GET", f"/api/v1/builds/{build_id}/notify"),
+        ]
+
+    async def test_an_unparseable_answer_reads_as_unset(self, monkeypatch):
+        """Unparseable must mean "no", and this is not a nicety.
+
+        A fabricated "yes" makes the linger loop clear the flag, re-read the
+        frontier, be told yes again, and never exit — while holding and
+        renewing the build's scheduler lease, so nothing else can drive that
+        build for the life of the container. Note the trigger is wider than
+        corruption: every field of ``BuildNotifyResult`` has a default, so a
+        bare ``{}`` validates cleanly to the model default.
+        """
+        from stardag.registry import _api_registry
+
+        monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
+
+        for body in ({}, {"needsTick": True}, {"needs_tick": "yes-ish"}):
+            registry = self._registry(
+                lambda request, b=body: httpx.Response(200, json=b)
+            )
+            result = await registry.build_get_notify_aio(uuid4())
+            assert result.needs_tick is False, body
+
+    async def test_a_missing_build_propagates_and_does_not_latch(self, monkeypatch):
+        """The discrimination the latch turns on: a *resource* 404 is a real
+        error, a *route* 404 is version skew. Getting this wrong would
+        disable the cheap read for the whole process on the first request
+        for a deleted build."""
+        from stardag.exceptions import NotFoundError
+        from stardag.registry import _api_registry
+
+        monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
+
+        registry = self._registry(
+            lambda request: httpx.Response(404, json={"detail": "Build not found"})
+        )
+
+        with pytest.raises(NotFoundError):
+            await registry.build_get_notify_aio(uuid4())
+        assert _api_registry._notify_read_route_missing is False
+
+    async def test_405_falls_back_to_the_frontier_and_latches(self, monkeypatch):
         from stardag.registry import _api_registry
 
         monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
@@ -1284,9 +1350,6 @@ class TestNotifyReadFallback:
         that does not exist, is a real failure and must propagate — silently
         degrading to the frontier would hide it for the life of the process.
         """
-        import httpx
-        import pytest
-
         from stardag.exceptions import APIError
         from stardag.registry import _api_registry
 

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import gzip
 import json
-from uuid import UUID
+from types import SimpleNamespace
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -1218,3 +1219,83 @@ class TestSDKVersionUnsupported:
         with pytest.raises(SDKVersionUnsupportedError) as excinfo:
             cap.registry.build_list_tick_summaries(UUID(_BUILD_ID))
         assert "nginx: client SDK too old for this gateway" in str(excinfo.value)
+
+
+class TestNotifyReadFallback:
+    """``GET /builds/{id}/notify`` against a server that does not have it.
+
+    The path exists on such a server for POST and DELETE, so the miss comes
+    back as **405**, not the missing-route 404 — and the fallback has to be
+    latched, because this runs on the linger poll of every lingering build
+    and a doomed request per poll is the cost the endpoint removes.
+    """
+
+    def _registry(self, handler):
+        import asyncio
+
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
+        registry._async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            auth=registry._auth,
+        )
+        registry._async_client_loop = asyncio.get_running_loop()
+        return registry
+
+    async def test_405_falls_back_to_the_frontier_and_latches(self, monkeypatch):
+        import httpx
+
+        from stardag.registry import _api_registry
+
+        monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
+
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(f"{request.method} {request.url.path}")
+            return httpx.Response(405, json={"detail": "Method Not Allowed"})
+
+        registry = self._registry(handler)
+        frontier_calls: list[UUID] = []
+
+        async def fake_frontier(build_id):
+            frontier_calls.append(build_id)
+            return SimpleNamespace(needs_tick=True)
+
+        registry.build_get_frontier_aio = fake_frontier  # type: ignore[method-assign]
+
+        build_id = uuid4()
+        first = await registry.build_get_notify_aio(build_id)
+        second = await registry.build_get_notify_aio(build_id)
+
+        assert first.needs_tick is True
+        assert second.needs_tick is True
+        assert frontier_calls == [build_id, build_id], "both answered by the frontier"
+        assert len(requested) == 1, (
+            "the missing route must be latched, not re-probed on every poll: "
+            f"{requested}"
+        )
+
+    async def test_a_real_error_is_not_swallowed(self, monkeypatch):
+        """Only a missing *route* falls back. A 500, or a 404 for a build
+        that does not exist, is a real failure and must propagate — silently
+        degrading to the frontier would hide it for the life of the process.
+        """
+        import httpx
+        import pytest
+
+        from stardag.exceptions import APIError
+        from stardag.registry import _api_registry
+
+        monkeypatch.setattr(_api_registry, "_notify_read_route_missing", False)
+
+        registry = self._registry(
+            lambda request: httpx.Response(500, json={"detail": "boom"})
+        )
+
+        with pytest.raises(APIError):
+            await registry.build_get_notify_aio(uuid4())
+        assert _api_registry._notify_read_route_missing is False


### PR DESCRIPTION
**Step 1 of STA-18.** The long-poll half is deliberately not here — see
"What this does not do".

The reactive tick's linger poll asks one question every few seconds, per
lingering build — *"has anything changed?"* — and asked it by fetching the
whole frontier: five queries including two window-function aggregates over
the event log, of which it read a single boolean.

## The endpoint

`GET /builds/{build_id}/notify` is that boolean: one row, nothing derived.

The notify path already had the right shape — `BuildNotifyResponse`, `POST`
to set, `DELETE` to clear. It was missing only the read.

`scheduler_live` is deliberately absent from the GET rather than reported as
`False`. The caller holds the lease, so the answer would only ever be
itself, and computing it costs the second table this endpoint exists to
avoid. Reporting `False` would be read by a caller as "nobody is
scheduling", which is worse than saying nothing.

## Not what the issue proposed, and why

The Direction was to poll the slim `GET /builds/{id}`, "it already returns
`needs_tick_at`". It does not — `BuildResponse` has no such field — and that
endpoint is not especially slim either: `_build_to_response` resolves the
triggering user and the build's last event, so it is ~3 queries for a
boolean. Adding the field there would also have put the flag on a
human-facing read model rather than on the scheduler-facing one that
already exists.

## Version skew

Against a server without the route, the poll falls back to the frontier read
it did before. The fallback is **latched per process**: the path exists on
such a server for `POST` and `DELETE`, so the miss comes back as a **405**,
not the missing-route 404 — and re-probing on every poll of every lingering
build is precisely the cost being removed.

`RegistryABC.build_get_notify`'s default delegates to the frontier, so a
custom backend keeps working untouched and can override for the cheap read.
It is deliberately not a constant: "always needs a tick" turns the linger
loop into a hot loop and "never" stalls the build until the watchdog, so
there is no safe direction to default to — only the real answer.

## Two test changes worth reading

- `FakeReactiveRegistry` now **overrides** the cheap read instead of
  inheriting the frontier-delegating default. A double that inherits it
  cannot distinguish "read the flag" from "read the frontier", which is the
  entire property under test.
- `test_flag_set_before_release_extends_the_linger` landed its wake-up
  between two frontier reads. The frontier is no longer read there at all,
  so it now hooks the notify reads — otherwise it would have kept passing
  while testing nothing.

`TestLingerPollCost` is the new one that states the claim directly: several
polls happen, and the frontier is read exactly once, by the pass itself.

## What this does not do

The second Done-when bullet — *"deep-chain latency per level is bounded by
the long-poll timeout, not the poll interval"* — is not addressed here, and
cannot be by this shape. It needs **push**, and the deployment runs
transaction pooling (`database_pooler_compat` disables asyncpg's prepared
statements), so `LISTEN/NOTIFY` cannot ride the pooled connection. A
server-side sleep-poll would move the poll rather than remove it, and at a
probe interval short enough to matter it would *increase* the query rate
against today's 3 s client poll.

Split out for its own evaluation, with a feasibility and load study, per
Anders.

## Verification

- SDK: **1405 passed** (`-m "not modal_live"`)
- API on Postgres: **701 passed**, 1 skipped
- `pyright src tests`: clean, both packages
- pre-commit on the changed files: clean
- **Live on the Modal+Neon dev stack**, server and `sd-e2e` redeployed from
  this branch. `/openapi.json` confirms the route is served
  (`[delete, get, post]` on `/builds/{build_id}/notify`), and **s4** passed
  with the linger poll going through it: B `lingered_out` 17:21:24, A'''s tick
  `neighbours=1` 17:22:06, B'''s woken tick terminal 17:22:10.

### What the poll actually costs

Measured against the live stack, 25 samples each, with a no-database route
(`/version`) as the RTT baseline so the server-side work is isolated:

| | small build | 127-task build |
| --- | --- | --- |
| RTT baseline | 175.7 ms | 177.8 ms |
| server-side `GET /notify` | **37.2 ms** | **40.0 ms** |
| server-side `GET /frontier` | **101.1 ms** | **103.7 ms** |
| ratio | 2.7x | 2.6x |

So ~64 ms of server work saved per poll, per lingering build. Two things
worth noting honestly: the ratio is flat from a small build to 127 tasks —
the frontier'''s fixed cost (five queries, two window aggregates) dominates at
these sizes rather than the task count — and measured from a laptop the RTT
swamps it, which it would not from inside Modal where ticks actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)