### PR TITLE
Run the live Modal test tier in CI

### DIFF
--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -14,12 +14,20 @@ name: Modal Live Tests
 
 on:
   schedule:
-    # 03:17 UTC -- off the hour, so it does not queue behind everyone else's
-    # midnight cron.
-    - cron: "17 3 * * *"
+    # Weekly, Monday 03:17 UTC. Off the hour so it does not queue behind
+    # everyone else's midnight cron.
+    #
+    # The schedule exists for one signal that no PR-triggered run produces:
+    # drift *underneath* us. `test_live_semantics.py` pins Modal platform
+    # behaviour ("so a Modal-side change is caught here rather than in
+    # production builds"), and image rebuilds re-resolve dependencies. Both
+    # change with time, not with commits. Weekly rather than nightly because
+    # that is the rate those actually change, and a scheduled run that goes
+    # red on platform latency and nobody reads is worse than no schedule.
+    - cron: "17 3 * * 1"
   workflow_dispatch:
   pull_request:
-    types: [labeled, synchronize, reopened, closed]
+    types: [opened, labeled, synchronize, reopened, closed]
 
 # Least privilege by default; the sweeper widens it for the two read-only
 # lookups it needs.
@@ -46,30 +54,80 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Whether to run, in one place with a readable log line saying why.
+  #
+  # Two ways in, and the path check is the important one: a label means
+  # remembering to apply it, which is the failure this whole tier exists to fix.
+  # The label stays as the manual override for a change that touches none of
+  # these paths but still warrants a live run -- a dependency bump, a selfhost
+  # change -- so it cannot be a `paths:` filter on the trigger. GitHub applies
+  # `paths:` to *every* activity type, which would silently swallow the label
+  # event too, and the closed-PR cleanup with it.
+  decide:
+    name: Decide whether to run
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR: ${{ github.event.pull_request.number }}
+          LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'modal-live') }}
+        run: |
+          set -euo pipefail
+
+          decision() {
+            echo "run=$1" >> "$GITHUB_OUTPUT"
+            echo "$2"
+            exit 0
+          }
+
+          [ "$EVENT" = "pull_request" ] || decision true "$EVENT -- running."
+
+          # Fork PRs receive no secrets, so this could only fail in require
+          # mode. Skipping is the honest outcome, not a green tick.
+          [ "$HEAD_REPO" = "$REPO" ] || decision false \
+            "PR is from a fork ($HEAD_REPO); GitHub withholds the Modal credentials."
+
+          [ "$LABELLED" = "true" ] && decision true "Labelled modal-live -- running."
+
+          # Everything the live tier actually exercises, plus the harness
+          # itself and the dependency list baked into the worker image.
+          changed=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+          if printf '%s\n' "$changed" | grep -qE \
+               '^(lib/stardag/src/stardag/(integration/modal|build|testing/modal)/|lib/stardag/tests/test_integration/test_modal/|lib/stardag/pyproject\.toml$|tox\.ini$|\.github/workflows/modal-live\.yml$)'; then
+            echo "Changed files touching the live tier:"
+            printf '%s\n' "$changed" | grep -E \
+              '^(lib/stardag/src/stardag/(integration/modal|build|testing/modal)/|lib/stardag/tests/test_integration/test_modal/|lib/stardag/pyproject\.toml$|tox\.ini$|\.github/workflows/modal-live\.yml$)' \
+              | sed 's/^/  /'
+            decision true "Running."
+          fi
+
+          decision false \
+            "No label and nothing changed under the live tier's paths. Add the 'modal-live' label to force a run."
+
   modal-live:
     name: Live Modal tier
     runs-on: ubuntu-latest
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     timeout-minutes: 25 # the suite measures ~6 minutes; this is slack, not a budget
-    # Two gates, and both matter:
+    # The same-repo restriction lives in `decide` above. It is the contributor
+    # check: a branch only exists here if the pusher has write access, and
+    # unlike an author allow-list it stays correct as the collaborator set
+    # changes.
     #
-    #  * `head.repo.full_name == github.repository` -- the branch is on this
-    #    repo, so whoever pushed it has write access. That is the contributor
-    #    check, and unlike an author allow-list it stays correct as the
-    #    collaborator set changes. Fork PRs get no secrets from GitHub on a
-    #    `pull_request` event anyway, so without this they would fail in require
-    #    mode rather than skip cleanly.
-    #
-    #  * the `modal-live` label -- opt-in, so a live run is always something
-    #    someone asked for.
-    #
-    # `pull_request_target` would let fork PRs run with the token in scope. That
-    # is the exfiltration path this design exists to avoid; do not "fix" the
-    # fork case that way.
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.action != 'closed' &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       contains(github.event.pull_request.labels.*.name, 'modal-live'))
+    # `pull_request_target` would let fork PRs run with the token in scope.
+    # That is the exfiltration path this design exists to avoid; do not "fix"
+    # the fork case that way.
     environment: modal-live-ci
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}

--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -21,11 +21,23 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened, closed]
 
+# Least privilege by default; the sweeper widens it for the two read-only
+# lookups it needs.
+permissions:
+  contents: read
+
 concurrency:
   # One live run per Modal environment at a time. This is what makes the
   # tier's fixed object names (`stardag-testing`, `stardag-testing-app`,
   # `stardag-testing-probe`, ...) safe without salting them per run: two runs
   # sharing an environment would redeploy the same app under each other.
+  #
+  # Note the environment is per *PR*, not per run: reruns and later pushes on
+  # the same PR reuse `ci-pr-<n>` and inherit whatever the previous run left in
+  # it. That is deliberate and safe -- task ids, outputs and probe keys are all
+  # salted per run, so the inherited state is inert -- and it keeps the volume
+  # warm across a PR's iterations. Serialisation is what makes it safe; without
+  # the group below, two runs would race the same app name.
   group: >-
     modal-live-${{ github.event_name == 'pull_request'
       && format('pr-{0}', github.event.pull_request.number)
@@ -141,6 +153,7 @@ jobs:
   cleanup-closed-pr:
     name: Delete the closed PR's Modal environment
     runs-on: ubuntu-latest
+    permissions: {}
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
@@ -170,6 +183,11 @@ jobs:
   sweep-stale-environments:
     name: Sweep stale Modal environments
     runs-on: ubuntu-latest
+    # `gh pr view` needs pull-requests, `gh run view` needs actions.
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
     needs: modal-live
     # `always()` is load-bearing: with `needs`, a failed or cancelled
     # modal-live would otherwise skip the sweeper -- and a red suite is exactly

--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -1,0 +1,216 @@
+name: Modal Live Tests
+
+# The `modal_live` test tier: stardag's engine driving a *real* Modal
+# workspace -- spawning detached workers, re-attaching to them by function call
+# id, and the platform semantics that detached execution depends on.
+#
+# It is not part of `ci.yml` because it costs real compute and needs
+# credentials, so it runs only when asked: nightly, on manual dispatch, or on a
+# pull request that a maintainer has labelled `modal-live`.
+#
+# Scope, stated plainly so this file is not mistaken for more than it is: the
+# workers here report to a NoOp registry. This tier covers Modal *execution*,
+# not registry interaction, and not the hosting of a deployed registry.
+
+on:
+  schedule:
+    # 03:17 UTC -- off the hour, so it does not queue behind everyone else's
+    # midnight cron.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened, closed]
+
+concurrency:
+  # One live run per Modal environment at a time. This is what makes the
+  # tier's fixed object names (`stardag-testing`, `stardag-testing-app`,
+  # `stardag-testing-probe`, ...) safe without salting them per run: two runs
+  # sharing an environment would redeploy the same app under each other.
+  group: >-
+    modal-live-${{ github.event_name == 'pull_request'
+      && format('pr-{0}', github.event.pull_request.number)
+      || (github.event_name == 'workflow_dispatch'
+          && format('manual-{0}', github.run_id) || 'main') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  modal-live:
+    name: Live Modal tier
+    runs-on: ubuntu-latest
+    timeout-minutes: 25 # the suite measures ~6 minutes; this is slack, not a budget
+    # Two gates, and both matter:
+    #
+    #  * `head.repo.full_name == github.repository` -- the branch is on this
+    #    repo, so whoever pushed it has write access. That is the contributor
+    #    check, and unlike an author allow-list it stays correct as the
+    #    collaborator set changes. Fork PRs get no secrets from GitHub on a
+    #    `pull_request` event anyway, so without this they would fail in require
+    #    mode rather than skip cleanly.
+    #
+    #  * the `modal-live` label -- opt-in, so a live run is always something
+    #    someone asked for.
+    #
+    # `pull_request_target` would let fork PRs run with the token in scope. That
+    # is the exfiltration path this design exists to avoid; do not "fix" the
+    # fork case that way.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'closed' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'modal-live'))
+    environment: modal-live-ci
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      # Required, and not merely cosmetic: `live_modal_guard` compares the
+      # active profile against STARDAG_MODAL_TEST_PROFILE, and modal.config
+      # resolves the active profile as `MODAL_PROFILE or "default"`. Without
+      # this line every run fails the guard in require mode.
+      MODAL_PROFILE: stardag-ci
+      STARDAG_MODAL_TEST_PROFILE: stardag-ci
+      # Require mode: fail rather than skip when credentials are missing or the
+      # profile does not match, so a misconfigured job cannot pass vacuously.
+      STARDAG_MODAL_LIVE_TESTS: "1"
+      # Build the worker image from *this checkout*, not from the last PyPI
+      # release. The `auto` default infers it from the install being editable,
+      # which is true under `uv sync` -- but a silent fallback would test the
+      # released stardag inside the container while the branch's code sits
+      # unexercised, and the job would still be green.
+      STARDAG_MODAL_LOCAL_STARDAG_SOURCE: "yes"
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # For a labelled PR, test the PR's own head. (Safe here precisely
+          # because the `if` above restricts this to same-repo branches.)
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Resolve the Modal environment for this run
+        id: env
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request)     name="ci-pr-${{ github.event.pull_request.number }}"; ephemeral=true ;;
+            workflow_dispatch) name="ci-manual-${{ github.run_id }}";               ephemeral=true ;;
+            *)                name="ci-main";                                       ephemeral=false ;;
+          esac
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "ephemeral=$ephemeral" >> "$GITHUB_OUTPUT"
+          echo "MODAL_ENVIRONMENT=$name" >> "$GITHUB_ENV"
+          echo "Modal environment: $name (ephemeral=$ephemeral)"
+
+      - name: Create the Modal environment
+        run: |
+          set -euo pipefail
+          name="${{ steps.env.outputs.name }}"
+          if uvx modal environment list --json | jq -e --arg n "$name" \
+               'any(.[]; .name == $n)' > /dev/null; then
+            echo "Environment '$name' already exists, reusing it."
+          else
+            uvx modal environment create "$name"
+          fi
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run the live Modal tier
+        run: tox -e stardag-modal-live
+
+      # Ephemeral environments take everything the tier leaves behind with them
+      # -- deployed apps, the `stardag-testing` volume, the probe's dict -- in
+      # one call. `ci-main` is kept, so the nightly path has no churn.
+      #
+      # `cancel-in-progress` means this step is sometimes skipped, so leaks are
+      # expected rather than exceptional; the sweeper job below is the backstop.
+      - name: Delete the Modal environment
+        if: always() && steps.env.outputs.ephemeral == 'true'
+        run: uvx modal environment delete "${{ steps.env.outputs.name }}" --yes
+
+  # --- Cleanup backstops -----------------------------------------------------
+
+  # A closed PR's environment goes immediately, rather than waiting for the
+  # nightly sweep. Runs for any closed PR whose environment might exist; a
+  # delete of a name that was never created is a no-op we tolerate rather than
+  # guard, since the alternative is a leaked environment.
+  cleanup-closed-pr:
+    name: Delete the closed PR's Modal environment
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    environment: modal-live-ci
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_PROFILE: stardag-ci
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Delete ci-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          name="ci-pr-${{ github.event.pull_request.number }}"
+          if uvx modal environment list --json | jq -e --arg n "$name" \
+               'any(.[]; .name == $n)' > /dev/null; then
+            uvx modal environment delete "$name" --yes
+          else
+            echo "No environment '$name' to delete."
+          fi
+
+  # The backstop for the runs whose own teardown never executed -- a cancelled
+  # run, a hard job failure. Keyed on GitHub state rather than age, because
+  # `modal environment list` reports no creation time.
+  sweep-stale-environments:
+    name: Sweep stale Modal environments
+    runs-on: ubuntu-latest
+    needs: modal-live
+    # `always()` is load-bearing: with `needs`, a failed or cancelled
+    # modal-live would otherwise skip the sweeper -- and a red suite is exactly
+    # when leaked environments accumulate.
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    environment: modal-live-ci
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_PROFILE: stardag-ci
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Delete environments whose PR is closed or whose run has finished
+        run: |
+          set -euo pipefail
+          uvx modal environment list --json \
+            | jq -r '.[].name
+                     | select(startswith("ci-pr-") or startswith("ci-manual-"))' \
+            | while read -r name; do
+                case "$name" in
+                  ci-pr-*)
+                    n="${name#ci-pr-}"
+                    state=$(gh pr view "$n" --repo "$GITHUB_REPOSITORY" \
+                              --json state -q .state 2>/dev/null || echo MISSING)
+                    if [ "$state" != "OPEN" ]; then
+                      echo "PR #$n is $state -- deleting $name"
+                      uvx modal environment delete "$name" --yes
+                    fi
+                    ;;
+                  ci-manual-*)
+                    id="${name#ci-manual-}"
+                    status=$(gh run view "$id" --repo "$GITHUB_REPOSITORY" \
+                               --json status -q .status 2>/dev/null || echo missing)
+                    if [ "$status" != "in_progress" ] && [ "$status" != "queued" ]; then
+                      echo "Run $id is $status -- deleting $name"
+                      uvx modal environment delete "$name" --yes
+                    fi
+                    ;;
+                esac
+              done

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -100,13 +100,58 @@ STARDAG_MODAL_TEST_PROFILE=<your-dev-profile> \
   uv run pytest tests/test_integration/test_modal -m modal_live
 ```
 
+Or through tox, which is what CI runs and which defaults to require mode:
+
+```bash
+STARDAG_MODAL_TEST_PROFILE=<your-dev-profile> tox -e stardag-modal-live
+```
+
 Gating (see `stardag.testing.modal.live_modal_guard`):
 
 - `STARDAG_MODAL_LIVE_TESTS`: `auto` (default: run if authenticated, else
-  skip), `1` (require: fail instead of skip — for CI), `0` (always skip).
+  skip), `1` (require: fail instead of skip), `0` (always skip). The
+  `stardag-modal-live` tox env sets `1`, because invoking it _is_ the request
+  to run the tier — `auto` would let a missing credential skip everything and
+  still exit 0.
 - `STARDAG_MODAL_TEST_PROFILE`: if set, live tests are skipped unless the
   active Modal profile matches. Recommended to always set this locally, so
   live tests can never run against a shared/production workspace by accident.
+
+The ordinary test envs exclude the tier twice over — `-m "not modal_live"`
+plus `STARDAG_MODAL_LIVE_TESTS=0`. Both are needed: marker deselection happens
+_after_ module import, so without the environment variable the guard still
+makes a Modal API call per module before deciding to skip.
+
+##### In CI
+
+`.github/workflows/modal-live.yml` runs the tier against a dedicated
+`stardag-ci` Modal workspace. It is **not** part of the normal CI run and is
+not a required check — it needs credentials, which GitHub does not give to
+pull requests from forks.
+
+| When                                                             | Modal environment    |
+| ---------------------------------------------------------------- | -------------------- |
+| A pull request labelled `modal-live`, from a branch on this repo | `ci-pr-<number>`     |
+| Manual `workflow_dispatch`                                       | `ci-manual-<run-id>` |
+| The schedule                                                     | `ci-main`            |
+
+**Label a PR `modal-live` if it touches `integration/modal/`, the build engine,
+or anything the deployed worker image is built from.** Nothing enforces this,
+so it is a habit rather than a gate.
+
+Each run gets its own Modal environment, and deleting that environment removes
+the apps, volumes and dicts inside it — so the tier can leave its fixed-name
+objects (`stardag-testing`, `stardag-testing-app`, ...) exactly where they are
+without concurrent runs colliding. A concurrency group serialises runs sharing
+an environment name, which is what makes those fixed names safe.
+
+**What the tier does and does not cover.** It exercises Modal _execution_:
+real containers, detached spawn and re-attach, retries, cancellation, timeout
+semantics. It does _not_ exercise registry interaction — the registries in
+these tests are `NoOpRegistry` subclasses, so claim arbitration and reactive
+wake-ups are simulated in-process rather than checked against the real API.
+Registry behaviour is covered separately by `app/stardag-api`'s own suite
+against Postgres.
 
 ### Linting & Formatting
 

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -129,15 +129,32 @@ makes a Modal API call per module before deciding to skip.
 not a required check — it needs credentials, which GitHub does not give to
 pull requests from forks.
 
-| When                                                             | Modal environment    |
-| ---------------------------------------------------------------- | -------------------- |
-| A pull request labelled `modal-live`, from a branch on this repo | `ci-pr-<number>`     |
-| Manual `workflow_dispatch`                                       | `ci-manual-<run-id>` |
-| The schedule                                                     | `ci-main`            |
+| When                                                                                                              | Modal environment    |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------- |
+| A pull request from a branch on this repo, that either touches the tier's paths or carries the `modal-live` label | `ci-pr-<number>`     |
+| Manual `workflow_dispatch`                                                                                        | `ci-manual-<run-id>` |
+| The weekly schedule                                                                                               | `ci-main`            |
 
-**Label a PR `modal-live` if it touches `integration/modal/`, the build engine,
-or anything the deployed worker image is built from.** Nothing enforces this,
-so it is a habit rather than a gate.
+**You do not normally need to do anything.** A pull request touching any of
+these runs the tier automatically:
+
+- `lib/stardag/src/stardag/integration/modal/`
+- `lib/stardag/src/stardag/build/`
+- `lib/stardag/src/stardag/testing/modal/`
+- `lib/stardag/tests/test_integration/test_modal/`
+- `lib/stardag/pyproject.toml` (the dependency list baked into the worker image)
+- `tox.ini`, `.github/workflows/modal-live.yml` (the harness itself)
+
+**The `modal-live` label is the manual override**, for a change that touches
+none of those and still warrants a live run — a dependency bump, a `selfhost`
+change, a hunch. The `Decide whether to run` job logs which rule applied and
+why, so a surprising skip is one click to explain.
+
+The schedule is weekly rather than nightly, and it is not there to catch
+regressions in merged code — the automatic trigger does that. It is there for
+the one signal no commit produces: drift underneath us. `test_live_semantics.py`
+pins Modal _platform_ behaviour, and rebuilt images re-resolve dependencies;
+both change with time rather than with commits.
 
 Each run gets its own Modal environment, and deleting that environment removes
 the apps, volumes and dicts inside it — so the tier can leave its fixed-name

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -94,6 +94,13 @@ stardag_app = StardagApp(
     worker_settings={
         "default": FunctionSettings(image=TEST_IMAGE, secrets=[TARGET_ROOTS_SECRET])
     },
+    # No registry to authenticate to: every live module drives this app with a
+    # NoOpRegistry or an in-process/file-backed stub, so the containers never
+    # call one. Leaving the default would make the whole live tier depend on a
+    # `stardag-api-key` Modal secret existing in whichever environment it runs
+    # in — an undeclared prerequisite that a developer workspace happens to
+    # satisfy and a fresh one does not.
+    stardag_api_key_secret=None,
 )
 
 finalize_result = stardag_app.finalize()
@@ -234,6 +241,7 @@ class TestUserVolumesOverride:
                     volumes={custom_path: user_volume},
                 )
             },
+            stardag_api_key_secret=None,  # see module-level app
         )
 
         result = app.finalize()
@@ -262,6 +270,7 @@ class TestUserVolumesOverride:
             "test-auto-add-app",
             builder_settings=FunctionSettings(image=TEST_IMAGE),
             worker_settings={"default": FunctionSettings(image=TEST_IMAGE)},
+            stardag_api_key_secret=None,  # see module-level app
         )
 
         result = app.finalize()

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
@@ -1,8 +1,8 @@
 """Round-trip tests for the optional disk-cache wrapper around
 ``ModalVolumeRemoteFileSystem``.
 
-These tests hit the **real** Modal API and create/delete files on a
-pre-existing ``stardag-testing`` volume in whichever
+These tests hit the **real** Modal API and create/delete files on the
+shared ``stardag-testing`` volume in whichever
 ``(workspace, environment)`` is currently active for your local Modal
 credentials. They run locally (no ``modal.Function``) — caching only
 applies to the API-based ``RemoteFileTarget`` path used outside Modal.
@@ -14,17 +14,11 @@ Pure configuration wiring is covered (without Modal auth) by
     profile/environment is selected before running — e.g. a personal/dev
     workspace, *not* a shared or production-adjacent one. Check with
     ``modal profile current`` and switch with
-    ``modal profile activate <profile>`` if needed. The ``stardag-testing``
-    volume must already exist in the active workspace/environment; these
-    tests deliberately do **not** auto-create it (test discovery should
-    not mutate external state). Create it once with
-    ``modal volume create stardag-testing`` if you intend to run these
-    tests locally.
-
-TODO: harden the setup so these tests can run in CI — pin to a dedicated
-test workspace/environment via ``MODAL_PROFILE`` / ``MODAL_ENVIRONMENT``,
-provision credentials as a CI secret, and gate on those being set
-instead of skipping silently on missing auth/volume.
+    ``modal profile activate <profile>`` if needed. Setting
+    ``STARDAG_MODAL_TEST_PROFILE`` turns that convention into an enforced
+    guard. The ``stardag-testing`` volume is created if missing by
+    :func:`~stardag.testing.modal.live_modal_guard`, which doubles as the
+    credential check, so no manual volume setup is needed.
 """
 
 import asyncio

--- a/lib/stardag/tests/test_integration/test_modal/test_env_overrides.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_env_overrides.py
@@ -230,6 +230,13 @@ class TestFinalizeWrapperBackwardCompat:
             worker_settings={
                 "default": FunctionSettings(image=modal.Image.debian_slim())
             },
+            # Keeps this unit test hermetic. Without it, finalize() asks Modal
+            # whether a `stardag-api-key` secret exists, so the test's outcome
+            # depends on the developer's ambient Modal profile: it passes with
+            # no credentials (the check is best-effort and skips) and with a
+            # profile whose environment happens to hold that secret, and fails
+            # with any other authenticated profile.
+            stardag_api_key_secret=None,
         )
 
         registered: dict = {}

--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,39 @@ envlist =
 # lib/stardag - Core SDK
 # ============================================================================
 [testenv:stardag-py{311,312,313,314}]
-description = Run tests for stardag package
+description = Run tests for stardag package (excludes the live Modal tier)
 skip_install = true
 allowlist_externals = uv
 change_dir = lib/stardag
+# Both halves are needed, and they do different jobs. `-m "not modal_live"`
+# deselects the tier; STARDAG_MODAL_LIVE_TESTS=0 stops `live_modal_guard` from
+# making a network round-trip per module first, because marker deselection
+# happens *after* module import. Without the env var an ordinary test run --
+# local or CI -- still talks to Modal seven times before deciding to skip.
+setenv =
+    STARDAG_MODAL_LIVE_TESTS = 0
 commands_pre =
     uv sync --active --all-extras
 commands =
-    uv run --active pytest --markdown-docs {posargs:tests}
+    uv run --active pytest --markdown-docs -m "not modal_live" {posargs:tests}
+
+# The live Modal tier. Deliberately absent from `envlist` and from the
+# [gh-actions] mapping below: it hits a real Modal workspace, so it runs only
+# when something asks for it by name -- the modal-live workflow, or a developer
+# who has exported the variables below.
+[testenv:stardag-modal-live]
+description = Run the live Modal test tier (hits a real Modal workspace)
+skip_install = true
+allowlist_externals = uv
+basepython = python3.12
+change_dir = lib/stardag
+passenv =
+    MODAL_*
+    STARDAG_MODAL_*
+commands_pre =
+    uv sync --active --all-extras
+commands =
+    uv run --active pytest -m modal_live {posargs:tests/test_integration/test_modal}
 
 [testenv:stardag-pyright]
 description = Type check stardag package

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,13 @@ change_dir = lib/stardag
 passenv =
     MODAL_*
     STARDAG_MODAL_*
+# Require mode by default. Running this env *is* the request to run the live
+# tier, so the "auto" default -- which skips on missing credentials or a
+# profile mismatch and still exits 0 -- would defeat its whole purpose. Still
+# overridable (`STARDAG_MODAL_LIVE_TESTS=auto tox -e stardag-modal-live`) for
+# anyone who wants the skip-if-unavailable behaviour.
+setenv =
+    STARDAG_MODAL_LIVE_TESTS = {env:STARDAG_MODAL_LIVE_TESTS:1}
 commands_pre =
     uv sync --active --all-extras
 commands =


### PR DESCRIPTION
## The problem

The `modal_live` test tier has never run anywhere but a developer's laptop.
With `STARDAG_MODAL_LIVE_TESTS` unset, `live_modal_guard` defaults to `"auto"`
— run if credentials work, skip otherwise — so CI collected all seven live
modules, made a Modal API call per module, and silently skipped every one for
lack of credentials. Nothing in the output said a tier had been skipped.

The gating for this was already written. Its own docstring says require mode is
for "CI jobs that are supposed to run the live tier, so misconfiguration
doesn't silently skip it." The job was just never built.

## What this adds

**`.github/workflows/modal-live.yml`** — runs the tier in require mode against
a dedicated `stardag-ci` Modal workspace:

| Trigger | Modal environment | Why |
| --- | --- | --- |
| PR touching the tier's paths, **or** carrying the `modal-live` label | `ci-pr-<n>` | the regression net |
| `workflow_dispatch` | `ci-manual-<run-id>` | any ref, maintainer-initiated |
| weekly `schedule` | `ci-main` (permanent) | drift underneath us |

**The trigger is by changed path, not by label.** A label would reintroduce the
exact failure this tier exists to fix — a regression caught only when someone
remembers. A PR touching `integration/modal/`, `build/`, `testing/modal/`, the
tier's own tests, `lib/stardag/pyproject.toml` (the dependency list baked into
the worker image) or the harness runs it without anyone deciding to. The label
survives as the manual override for changes that touch none of those.

This is a `decide` job rather than a `paths:` filter on the trigger, because
GitHub applies `paths:` to *every* activity type — it would swallow the
`labeled` event too, and take the closed-PR cleanup with it. The job logs which
rule applied, so a surprising skip explains itself instead of looking broken.

**The weekly schedule is not the regression net** — the path trigger is. It
exists for the one signal no commit produces: Modal platform behaviour changing
under us (which is what `test_live_semantics.py` pins) and rebuilt images
re-resolving dependencies. Both move with time rather than with commits, and
neither moves nightly.

The PR path also requires the branch to live on this repo. That is the
contributor check: a branch only exists here if the pusher has write access, so
the set is exactly the collaborators and it stays correct as that set changes.
Fork PRs receive no secrets from GitHub on a `pull_request` event, so they skip
with a log line rather than failing in require mode. **`pull_request_target` is
deliberately not used** — it runs fork code with the Modal token in scope.

Not a required status check, and it cannot be one: fork PRs can never run it,
and a required check that never reports reads as pending forever.

**One Modal environment per run**, with a concurrency group keyed on the same
name. That is what makes the tier's fixed object names (`stardag-testing`,
`stardag-testing-app`, `stardag-testing-probe`, …) safe under concurrent runs
without salting them per run. Teardown is one call: deleting the environment
takes the deployed apps, the test volume and the probe's dict with it. Two
backstops — a PR-closed job and a nightly sweeper keyed on GitHub state — catch
the runs whose own teardown never executed, since `cancel-in-progress` can kill
a job before its cleanup step.

**`tox.ini`** — a `stardag-modal-live` env (absent from `envlist` and the
`[gh-actions]` mapping, so only something asking for it by name runs it), and
the ordinary test envs now exclude the tier *twice over*. The marker deselects
it; `STARDAG_MODAL_LIVE_TESTS=0` stops the guard making a network round-trip
per module first. Both are needed — marker deselection happens after module
import, so without the env var every ordinary test run, local or CI, still
talks to Modal seven times before deciding to skip.

## Two bugs found by running it against a fresh workspace

**The tier had an undeclared prerequisite.** `test__app.py` built its
`StardagApp` without `stardag_api_key_secret=None`, so `finalize()` required a
Modal secret named `stardag-api-key` to exist in whichever environment the
tests ran in. That secret happens to exist in the workspace these tests have
always been run from, so the requirement was invisible; in a fresh workspace
the whole tier errors at collection before a single test runs.

Nothing in the tier needs it — every registry across the seven modules is a
`NoOpRegistry` subclass, in-process or file-backed, so no container here ever
authenticates to a registry. Creating the secret instead would add a real
credential to the setup of every environment the tier runs in, to satisfy a
dependency that is not real.

**A unit test's outcome depended on the ambient Modal profile.**
`test_env_overrides.py` let `finalize()` ask Modal whether that same secret
existed. The check is best-effort, so it passes with no credentials *and* with
a profile whose environment happens to hold the secret — and fails with any
other authenticated profile. It now passes identically under three different
ambient configurations.

## Verification

- **33 passed in 5m16s** against a real workspace, on this branch.
- **Require mode bites**: a bad token and a mismatched
  `STARDAG_MODAL_TEST_PROFILE` each exit non-zero at collection, rather than
  skipping. This is what stops the job passing vacuously.
- **Ephemeral environments are free**: deploying into a brand-new environment
  in the same workspace took 49s including the deploy, indistinguishable from a
  warm one — Modal's image layer cache is workspace-level. This is why the job
  can afford an environment per PR.
- `timeout-minutes: 25` is set against the measured ~6 minutes.
- The `decide` logic was verified offline across nine cases: schedule,
  dispatch, fork PR (skips even when labelled), labelled with unrelated paths,
  each triggering path in turn, and unrelated paths unlabelled.
- **And it is running on this PR**, which touches `tox.ini` and the workflow —
  the path trigger fired on itself, where the two earlier pushes show `skipped`.

## Scope — what this does *not* cover

Worth stating plainly, because the tier is easy to credit with more than it
does. These tests drive **real Modal execution** with a **simulated registry**:
the claim arbitration and reactive-scheduling behaviours are exercised against
in-process reimplementations of the registry's semantics, which can stay green
while the real API's version diverges. Registry behaviour itself is covered
separately by the API's own suite against Postgres and by the docker-compose
integration tests.

The gap neither covers is the crossing: a real Modal worker reporting to a real
registry over the network. That needs a reachable deployed registry and is a
larger piece of work, tracked separately.
