### PR TITLE
Assert the Modal workspace, not the profile name, in the live guard

### DIFF
--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -5,8 +5,8 @@ name: Modal Live Tests
 # id, and the platform semantics that detached execution depends on.
 #
 # It is not part of `ci.yml` because it costs real compute and needs
-# credentials, so it runs only when asked: nightly, on manual dispatch, or on a
-# pull request that a maintainer has labelled `modal-live`.
+# credentials, so it runs only when asked: weekly, on manual dispatch, or on a
+# pull request that touches the tier's paths or carries the `modal-live` label.
 #
 # Scope, stated plainly so this file is not mistaken for more than it is: the
 # workers here report to a NoOp registry. This tier covers Modal *execution*,
@@ -132,12 +132,13 @@ jobs:
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-      # Required, and not merely cosmetic: `live_modal_guard` compares the
-      # active profile against STARDAG_MODAL_TEST_PROFILE, and modal.config
-      # resolves the active profile as `MODAL_PROFILE or "default"`. Without
-      # this line every run fails the guard in require mode.
-      MODAL_PROFILE: stardag-ci
-      STARDAG_MODAL_TEST_PROFILE: stardag-ci
+      # The workspace the CI credentials belong to. Asserted against the
+      # workspace resolved from the token itself, rather than against a
+      # profile name -- `MODAL_PROFILE` selects a section of a `.modal.toml`,
+      # but `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` take precedence over that
+      # file and are not bound to the name, so a profile name asserts nothing
+      # here.
+      STARDAG_MODAL_TEST_WORKSPACE: andhus
       # Require mode: fail rather than skip when credentials are missing or the
       # profile does not match, so a misconfigured job cannot pass vacuously.
       STARDAG_MODAL_LIVE_TESTS: "1"
@@ -220,7 +221,6 @@ jobs:
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-      MODAL_PROFILE: stardag-ci
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -257,7 +257,6 @@ jobs:
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-      MODAL_PROFILE: stardag-ci
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Install uv
@@ -265,6 +264,13 @@ jobs:
       - name: Delete environments whose PR is closed or whose run has finished
         run: |
           set -euo pipefail
+          # Two filters, both required, and the only names ever passed to
+          # `environment delete`: the jq select below and the case arms. No
+          # other environment in the workspace is reachable from here.
+          #
+          # An indeterminate lookup keeps the environment rather than deleting
+          # it. "I could not tell, therefore delete" is the wrong default for
+          # an irreversible operation; the next sweep will settle it.
           uvx modal environment list --json \
             | jq -r '.[].name
                      | select(startswith("ci-pr-") or startswith("ci-manual-"))' \
@@ -273,8 +279,10 @@ jobs:
                   ci-pr-*)
                     n="${name#ci-pr-}"
                     state=$(gh pr view "$n" --repo "$GITHUB_REPOSITORY" \
-                              --json state -q .state 2>/dev/null || echo MISSING)
-                    if [ "$state" != "OPEN" ]; then
+                              --json state -q .state 2>/dev/null || echo LOOKUP_FAILED)
+                    if [ "$state" = "LOOKUP_FAILED" ]; then
+                      echo "Could not determine the state of PR #$n -- keeping $name"
+                    elif [ "$state" != "OPEN" ]; then
                       echo "PR #$n is $state -- deleting $name"
                       uvx modal environment delete "$name" --yes
                     fi
@@ -282,8 +290,10 @@ jobs:
                   ci-manual-*)
                     id="${name#ci-manual-}"
                     status=$(gh run view "$id" --repo "$GITHUB_REPOSITORY" \
-                               --json status -q .status 2>/dev/null || echo missing)
-                    if [ "$status" != "in_progress" ] && [ "$status" != "queued" ]; then
+                               --json status -q .status 2>/dev/null || echo LOOKUP_FAILED)
+                    if [ "$status" = "LOOKUP_FAILED" ]; then
+                      echo "Could not determine the state of run $id -- keeping $name"
+                    elif [ "$status" != "in_progress" ] && [ "$status" != "queued" ]; then
                       echo "Run $id is $status -- deleting $name"
                       uvx modal environment delete "$name" --yes
                     fi

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -114,8 +114,17 @@ Gating (see `stardag.testing.modal.live_modal_guard`):
   to run the tier — `auto` would let a missing credential skip everything and
   still exit 0.
 - `STARDAG_MODAL_TEST_PROFILE`: if set, live tests are skipped unless the
-  active Modal profile matches. Recommended to always set this locally, so
-  live tests can never run against a shared/production workspace by accident.
+  active Modal profile matches. Convenient locally, where credentials come
+  from a `~/.modal.toml` profile and the name therefore means something.
+- `STARDAG_MODAL_TEST_WORKSPACE`: if set, the workspace the credentials
+  **actually belong to** must match — resolved from the token itself. Prefer
+  this wherever credentials come from the environment rather than a profile,
+  CI most obviously. `MODAL_PROFILE` selects a section of `~/.modal.toml`, but
+  `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` take precedence over that file and are
+  not bound to the profile name, so a profile name asserts nothing there.
+
+Set one of the two whenever you run the live tier, so it can never reach a
+shared or production-adjacent workspace by accident.
 
 The ordinary test envs exclude the tier twice over — `-m "not modal_live"`
 plus `STARDAG_MODAL_LIVE_TESTS=0`. Both are needed: marker deselection happens
@@ -124,8 +133,9 @@ makes a Modal API call per module before deciding to skip.
 
 ##### In CI
 
-`.github/workflows/modal-live.yml` runs the tier against a dedicated
-`stardag-ci` Modal workspace. It is **not** part of the normal CI run and is
+`.github/workflows/modal-live.yml` runs the tier against the `andhus` Modal
+workspace, asserted via `STARDAG_MODAL_TEST_WORKSPACE`. It is **not** part of
+the normal CI run and is
 not a required check — it needs credentials, which GitHub does not give to
 pull requests from forks.
 

--- a/lib/stardag/src/stardag/testing/modal/_live.py
+++ b/lib/stardag/src/stardag/testing/modal/_live.py
@@ -16,6 +16,16 @@ dicts, and run containers. They are gated centrally by
   This guards against accidentally running live tests — which create
   apps/volumes visible to the whole workspace — against a shared or
   production-adjacent profile.
+- ``STARDAG_MODAL_TEST_WORKSPACE``: if set, the workspace the *credentials
+  actually belong to* must match. Prefer this wherever the credentials come
+  from the environment rather than from a ``.modal.toml`` profile — CI, most
+  obviously. ``STARDAG_MODAL_TEST_PROFILE`` compares a profile *name*, and a
+  profile name is self-asserted: ``MODAL_PROFILE`` selects a section of a
+  config file, but ``MODAL_TOKEN_ID`` / ``MODAL_TOKEN_SECRET`` take
+  precedence over that file and are not bound to the name at all. So the
+  profile check can pass while the token points somewhere else entirely. The
+  workspace check resolves the workspace from the token itself, which is the
+  thing worth asserting.
 
 All live test modules should also carry ``pytestmark = pytest.mark.modal_live``
 so the live tier can be excluded wholesale with ``pytest -m "not modal_live"``.
@@ -24,11 +34,45 @@ so the live tier can be excluded wholesale with ``pytest -m "not modal_live"``.
 from __future__ import annotations
 
 import os
+import typing
 
 DEFAULT_TEST_VOLUME = "stardag-testing"
 
 _TRUE = ("1", "true", "require")
 _FALSE = ("0", "false", "skip")
+
+
+_WORKSPACE_UNRESOLVED = object()
+_workspace_cache: object | str | None = _WORKSPACE_UNRESOLVED
+
+
+def _active_modal_workspace() -> str | None:
+    """The workspace the configured Modal credentials belong to.
+
+    Resolved from the token via Modal's own workspace lookup, deliberately
+    *not* from ``STARDAG_MODAL_WORKSPACE`` — an env var a caller can set to
+    any value is no use as a guard. Returns None when it cannot be
+    determined (no credentials, no network, an API surface change), which
+    the caller treats as a failed assertion rather than a pass.
+
+    Cached: the guard runs once per live module, and this is a network
+    round trip.
+    """
+    global _workspace_cache
+    if _workspace_cache is not _WORKSPACE_UNRESOLVED:
+        return typing.cast("str | None", _workspace_cache)
+
+    workspace: str | None
+    try:
+        import asyncio
+
+        from stardag.integration.modal._metadata import _lookup_modal_workspace_aio
+
+        workspace = asyncio.run(_lookup_modal_workspace_aio())
+    except Exception:
+        workspace = None
+    _workspace_cache = workspace
+    return workspace
 
 
 def _active_modal_profile() -> str | None:
@@ -76,6 +120,23 @@ def live_modal_guard(volume_name: str = DEFAULT_TEST_VOLUME) -> None:
                 f"Active Modal profile {active!r} does not match "
                 f"STARDAG_MODAL_TEST_PROFILE={expected_profile!r}"
             )
+            if required:
+                pytest.fail(msg)
+            pytest.skip(msg, allow_module_level=True)
+
+    # Before the credential check below, which *creates* a volume: verifying
+    # the workspace only after having written to it would be backwards.
+    expected_workspace = os.environ.get("STARDAG_MODAL_TEST_WORKSPACE")
+    if expected_workspace:
+        active_workspace = _active_modal_workspace()
+        if active_workspace != expected_workspace:
+            msg = (
+                f"Modal credentials resolve to workspace "
+                f"{active_workspace!r}, which does not match "
+                f"STARDAG_MODAL_TEST_WORKSPACE={expected_workspace!r}"
+            )
+            if active_workspace is None:
+                msg += " (no credentials, or the workspace lookup failed)"
             if required:
                 pytest.fail(msg)
             pytest.skip(msg, allow_module_level=True)

--- a/lib/stardag/src/stardag/testing/modal/_live.py
+++ b/lib/stardag/src/stardag/testing/modal/_live.py
@@ -52,26 +52,42 @@ def _active_modal_workspace() -> str | None:
     Resolved from the token via Modal's own workspace lookup, deliberately
     *not* from ``STARDAG_MODAL_WORKSPACE`` — an env var a caller can set to
     any value is no use as a guard. Returns None when it cannot be
-    determined (no credentials, no network, an API surface change), which
-    the caller treats as a failed assertion rather than a pass.
+    determined (no credentials, no network, a running event loop, an API
+    surface change), which the caller treats as a failed assertion rather
+    than a pass.
 
-    Cached: the guard runs once per live module, and this is a network
-    round trip.
+    **Only a successful resolution is cached.** The guard runs once per
+    live module — seven times over the tier — so caching the happy path is
+    worth a round trip. Caching a *failure* would be actively wrong: a
+    None is always read as a mismatch, so one transient error would fail
+    every remaining module for the rest of the process, and re-running the
+    lookup costs nothing that matters when the alternative is a wrong
+    answer.
     """
     global _workspace_cache
     if _workspace_cache is not _WORKSPACE_UNRESOLVED:
         return typing.cast("str | None", _workspace_cache)
 
-    workspace: str | None
-    try:
-        import asyncio
+    import asyncio
 
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # no loop: `asyncio.run` below is available
+    else:
+        # Called from inside a running loop, where `asyncio.run` raises.
+        # Not a resolution attempt, so nothing to cache.
+        return None
+
+    try:
         from stardag.integration.modal._metadata import _lookup_modal_workspace_aio
 
         workspace = asyncio.run(_lookup_modal_workspace_aio())
     except Exception:
-        workspace = None
-    _workspace_cache = workspace
+        return None
+
+    if workspace is not None:
+        _workspace_cache = workspace
     return workspace
 
 

--- a/lib/stardag/tests/test_integration/test_modal/test__live_guard.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__live_guard.py
@@ -138,6 +138,65 @@ class TestOrdering:
         assert volume_spy == [], "the wrong workspace was written to"
 
 
+class TestWorkspaceCaching:
+    """Only a successful resolution is cached.
+
+    A None is always read as a mismatch, so caching one would turn a single
+    transient failure — or one call from inside a running event loop — into a
+    failure for every remaining live module in the process.
+    """
+
+    def _patch_lookup(self, monkeypatch, results):
+        """Feed `_lookup_modal_workspace_aio` a sequence of outcomes."""
+        calls = {"n": 0}
+
+        async def _lookup():
+            i = calls["n"]
+            calls["n"] += 1
+            outcome = results[min(i, len(results) - 1)]
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        import stardag.integration.modal._metadata as meta
+
+        monkeypatch.setattr(meta, "_lookup_modal_workspace_aio", _lookup)
+        return calls
+
+    def test_a_failed_lookup_does_not_poison_later_calls(self, monkeypatch):
+        calls = self._patch_lookup(
+            monkeypatch, [ConnectionError("transient"), "the-workspace"]
+        )
+
+        assert _live._active_modal_workspace() is None
+        assert _live._active_modal_workspace() == "the-workspace"
+        assert calls["n"] == 2, "the failure was cached instead of retried"
+
+    def test_a_successful_lookup_is_cached(self, monkeypatch):
+        calls = self._patch_lookup(monkeypatch, ["the-workspace"])
+
+        assert _live._active_modal_workspace() == "the-workspace"
+        assert _live._active_modal_workspace() == "the-workspace"
+        assert calls["n"] == 1, "the happy path should cost one round trip"
+
+    def test_a_running_event_loop_yields_none_without_caching(self, monkeypatch):
+        """`asyncio.run` raises inside a running loop. That is not a
+        resolution attempt, so it must not be recorded as one."""
+        import asyncio
+
+        calls = self._patch_lookup(monkeypatch, ["the-workspace"])
+
+        async def _in_a_loop():
+            return _live._active_modal_workspace()
+
+        assert asyncio.run(_in_a_loop()) is None
+        assert calls["n"] == 0, "no lookup should be attempted inside a loop"
+
+        # Outside the loop it resolves normally — the earlier None stuck
+        # nothing to the cache.
+        assert _live._active_modal_workspace() == "the-workspace"
+
+
 class TestDisabled:
     """``STARDAG_MODAL_LIVE_TESTS=0`` short-circuits before any network call."""
 

--- a/lib/stardag/tests/test_integration/test_modal/test__live_guard.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__live_guard.py
@@ -1,0 +1,154 @@
+"""Unit tier: the gating in ``stardag.testing.modal._live``.
+
+No credentials and no network — the workspace lookup is monkeypatched. These
+cover the guard's own decisions, which are otherwise only exercised by the
+live tier they gate (and therefore not at all when it is skipped).
+
+Note ``pytest.fail`` and ``pytest.skip`` raise ``BaseException`` subclasses,
+so the distinction between them is asserted with ``pytest.fail.Exception`` /
+``pytest.skip.Exception`` rather than a bare ``Exception``.
+"""
+
+import pytest
+
+from stardag.testing.modal import _live
+
+FAILED = pytest.fail.Exception
+SKIPPED = pytest.skip.Exception
+
+
+@pytest.fixture(autouse=True)
+def _clear_workspace_cache():
+    """The workspace lookup is cached across calls; isolate each test."""
+    _live._workspace_cache = _live._WORKSPACE_UNRESOLVED
+    yield
+    _live._workspace_cache = _live._WORKSPACE_UNRESOLVED
+
+
+@pytest.fixture(autouse=True)
+def _no_profile_guard(monkeypatch):
+    """Keep these tests about the workspace check alone."""
+    monkeypatch.delenv("STARDAG_MODAL_TEST_PROFILE", raising=False)
+
+
+@pytest.fixture
+def workspace(monkeypatch):
+    """Pin what the credentials resolve to, without touching Modal."""
+
+    def _set(name: str | None):
+        monkeypatch.setattr(_live, "_active_modal_workspace", lambda: name)
+
+    return _set
+
+
+@pytest.fixture
+def volume_spy(monkeypatch):
+    """Record whether the credential check was reached, without a network call."""
+    import modal
+
+    calls: list[str] = []
+
+    def _from_name(name, **kwargs):
+        calls.append(name)
+        raise AssertionError("stop here")  # not reached in mismatch cases
+
+    monkeypatch.setattr(modal.Volume, "from_name", staticmethod(_from_name))
+    return calls
+
+
+class TestWorkspaceAssertion:
+    """``STARDAG_MODAL_TEST_WORKSPACE`` checks the token, not a label."""
+
+    def test_matching_workspace_falls_through_to_the_credential_check(
+        self, monkeypatch, workspace, volume_spy
+    ):
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "some-workspace")
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "1")
+        workspace("some-workspace")
+
+        with pytest.raises(AssertionError):
+            _live.live_modal_guard("a-volume")
+        assert volume_spy == ["a-volume"]
+
+    def test_mismatched_workspace_fails_in_require_mode(self, monkeypatch, workspace):
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "intended-workspace")
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "1")
+        workspace("some-other-workspace")
+
+        with pytest.raises(FAILED) as exc:
+            _live.live_modal_guard()
+        assert "some-other-workspace" in str(exc.value)
+        assert "intended-workspace" in str(exc.value)
+
+    def test_mismatched_workspace_skips_in_auto_mode(self, monkeypatch, workspace):
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "intended-workspace")
+        monkeypatch.delenv("STARDAG_MODAL_LIVE_TESTS", raising=False)
+        workspace("some-other-workspace")
+
+        with pytest.raises(SKIPPED):
+            _live.live_modal_guard()
+
+    def test_unresolvable_workspace_is_a_failure_not_a_pass(
+        self, monkeypatch, workspace
+    ):
+        """A lookup that returns nothing must not satisfy the assertion.
+
+        This is the case that matters: if an unresolvable workspace counted as
+        a match, the guard would wave through exactly what it exists to catch.
+        """
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "intended-workspace")
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "1")
+        workspace(None)
+
+        with pytest.raises(FAILED) as exc:
+            _live.live_modal_guard()
+        assert "workspace lookup failed" in str(exc.value)
+
+    def test_unset_workspace_var_skips_the_check_entirely(
+        self, monkeypatch, volume_spy
+    ):
+        """Opt-in: no variable, no assertion — local runs are unaffected."""
+        monkeypatch.delenv("STARDAG_MODAL_TEST_WORKSPACE", raising=False)
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "1")
+
+        def _explode():
+            raise AssertionError("workspace must not be looked up when unset")
+
+        monkeypatch.setattr(_live, "_active_modal_workspace", _explode)
+
+        with pytest.raises(AssertionError, match="stop here"):
+            _live.live_modal_guard("a-volume")
+        assert volume_spy == ["a-volume"]
+
+
+class TestOrdering:
+    """The workspace is asserted before anything writes to it."""
+
+    def test_workspace_is_checked_before_the_volume_is_created(
+        self, monkeypatch, workspace, volume_spy
+    ):
+        """The credential check creates a volume. Verifying the workspace
+        afterwards would mean having already written to the wrong one."""
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "intended-workspace")
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "1")
+        workspace("some-other-workspace")
+
+        with pytest.raises(FAILED, match="does not match"):
+            _live.live_modal_guard()
+        assert volume_spy == [], "the wrong workspace was written to"
+
+
+class TestDisabled:
+    """``STARDAG_MODAL_LIVE_TESTS=0`` short-circuits before any network call."""
+
+    def test_disabled_skips_without_looking_anything_up(self, monkeypatch):
+        monkeypatch.setenv("STARDAG_MODAL_LIVE_TESTS", "0")
+        monkeypatch.setenv("STARDAG_MODAL_TEST_WORKSPACE", "intended-workspace")
+
+        def _explode():
+            raise AssertionError("nothing should be looked up when disabled")
+
+        monkeypatch.setattr(_live, "_active_modal_workspace", _explode)
+
+        with pytest.raises(SKIPPED, match="disabled"):
+            _live.live_modal_guard()


### PR DESCRIPTION
## The profile check asserts a label, not a workspace

`live_modal_guard` can require that the active Modal profile matches
`STARDAG_MODAL_TEST_PROFILE` before letting the live tier run. That works
locally, where credentials come from a `~/.modal.toml` profile and the name
therefore corresponds to something.

It asserts nothing wherever credentials come from the environment instead.
`MODAL_PROFILE` selects a *section of a config file*, but `MODAL_TOKEN_ID` /
`MODAL_TOKEN_SECRET` take precedence over that file and are not bound to the
profile name at all — and with no config file present, `modal.config` resolves
the profile to `MODAL_PROFILE or "default"` regardless of whose token is
configured. So the check compares a string to itself while the token points
wherever it points. CI is the obvious case.

## `STARDAG_MODAL_TEST_WORKSPACE`

Compares against the workspace resolved from the **token itself**, via Modal's
own workspace lookup — deliberately not from `STARDAG_MODAL_WORKSPACE`, since
an environment variable a caller can set to any value is no use as a guard.

Two details that matter more than they look:

- **It runs before the credential check**, which creates the test volume.
  Verifying which workspace you are in only after having written to it would
  be backwards.
- **An unresolvable workspace is a mismatch, not a pass.** If a failed lookup
  counted as satisfied, the guard would wave through exactly the situation it
  exists to catch.

`STARDAG_MODAL_TEST_PROFILE` is unchanged and still the convenient thing
locally. The two compose; either one can gate a run.

## Tests

The guard's own decisions had no unit coverage — they were exercised only by
the live tier they gate, and therefore not at all whenever that tier was
skipped, which was every CI run until recently. Seven tests, no credentials
and no network (the lookup is monkeypatched), covering: match, mismatch under
require mode, mismatch under auto mode, unresolvable workspace, the variable
being unset, ordering relative to the volume creation, and the disabled
short-circuit.

Note `pytest.fail` / `pytest.skip` raise `BaseException` subclasses, so the
fail-vs-skip distinction is asserted with `pytest.fail.Exception` /
`pytest.skip.Exception` rather than a bare `Exception` — the latter silently
catches neither.

## Also: the sweeper's failure default

`sweep-stale-environments` asked GitHub for the state of the PR or run an
environment belonged to, and deleted the environment when that lookup failed.
"I could not determine the state, therefore delete" is the wrong default for
an irreversible operation. It now keeps the environment and lets the next
sweep settle it.

The name filters are untouched: only `ci-pr-*` and `ci-manual-*` are ever
candidates, behind two independent checks.

## Workflow

Names `andhus` as the workspace its credentials belong to, via the new
variable, and drops the profile variables that asserted nothing there.

Verified against live credentials: asserting a workspace the token does not
belong to fails at collection in about a second, and asserting the right one
collects normally.
