### PR TITLE
Server release 0.2.0: changelog split, version bump, and the release cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,30 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   longest live input, a couple of stale `RUNNING` builds would be enough to
   keep the tick function warm, however few they are.
 
-## [0.21.0] — 2026-08-29
+- Default prebuilt server image bumped to `server-v0.2.0`
+  (`DEFAULT_SERVER_VERSION = "0.2.0"`) — the server version this SDK release
+  is tested against.
+
+### Deployment
+
+- **Server image `0.2.0`**, the first server release since `0.1.2`
+  (2026-08-12). It carries the Registry API and UI changes recorded under
+  0.19.0 — apart from the SQL-injection fix, which shipped in `0.1.2` itself
+  — plus those under 0.21.0 and 0.22.0: `INTERRUPTED` as a first-class task
+  status and `POST /builds/{id}/tasks/{task_id}/interrupt`,
+  `POST /builds/{id}/notify` reporting `scheduler_live`,
+  `POST /builds/wake-candidates`, and the `builds.tick_requested_at`
+  migration (`97ce4e3cbf32`). It also carries the `python-jose` → `PyJWT`
+  swap for token auth and raised security floors on the API's transitive
+  dependencies and the UI's build tooling. Minor rather than patch: the HTTP
+  surface grew and there is a schema migration. Self-hosters upgrade with
+  `stardag self-host upgrade`.
+
+  A self-hosted `0.1.2` predates `wake-candidates`, so an SDK on the v0.22.0
+  line talking to it degrades to the previous behaviour — cross-build
+  wake-ups arrive only via the watchdog — rather than failing.
+
+## [0.22.0] — 2026-08-30
 
 ### SDK
 
@@ -118,6 +141,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 - The reaper's idleness signal no longer counts `needs_tick_at`: the flag
   is written by other builds' transitions now, and was redundant with the
   event stream before.
+
+## [0.21.0] — 2026-08-29
+
+### SDK
 
 - **The reactive scheduler no longer logs an ERROR for a task-store miss it
   recovers from.** `BuildTaskStore.load_task` logged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,11 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   longest live input, a couple of stale `RUNNING` builds would be enough to
   keep the tick function warm, however few they are.
 
-- Default prebuilt server image bumped to `server-v0.2.0`
-  (`DEFAULT_SERVER_VERSION = "0.2.0"`) — the server version this SDK release
-  is tested against.
+- Default prebuilt server image bumped to `0.2.0`
+  (`DEFAULT_SERVER_VERSION = "0.2.0"`, from the `server-v0.2.0` release) —
+  the server version this SDK release is tested against. The image tag and
+  `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git tag
+  only.
 
 ### Deployment
 

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -283,6 +283,34 @@ Before tagging, make sure `CHANGELOG.md` has an entry covering the
 release's Registry API / UI / Deployment changes (move them out of
 `[Unreleased]`) — the GitHub release links to it.
 
+### When to cut one
+
+**After each significant change to the Registry API or the UI**, not in
+batches. The image is the only route those changes have to a self-hosted
+deployment: the hosted service builds from a commit, so it always runs the
+newest API, but a self-hoster runs whatever the last `server-v*` tag built.
+An unreleased API change therefore reaches nobody outside the hosted
+deployment.
+
+Letting releases lag has a specific failure mode, and it is silent. Version
+skew degrades gracefully by design — an older registry answers nothing to an
+endpoint it does not have, and the SDK falls back — so a self-hoster on a
+stale image sees no error. They see a feature they upgraded the SDK for
+quietly not working. `server-v0.1.2` sat for 18 days that way, through six
+SDK releases (v0.19.0 → v0.22.0) — including the cross-build wake-up
+endpoints v0.22.0's headline feature is built on.
+
+"Significant" means anything a user could notice: new or changed endpoints, a
+schema migration, a UI change, a dependency swap on the auth or security
+path. A pure refactor with no external surface can wait for the next one.
+Bump the minor when the HTTP surface grows or there is a migration, the patch
+for fixes and dependency floors.
+
+Bump `DEFAULT_SERVER_VERSION` in the same PR — the pin is what a fresh
+`stardag self-host up` gets. Self-hosters who would rather track releases as
+they land deploy with `--server-version latest`; see
+[Updating to a new version](docs/docs/how-to/self-host-modal.md#updating-to-a-new-version).
+
 ### Dropping support for older SDKs
 
 The hosted service always runs the latest API, so the compatibility case

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -307,9 +307,7 @@ Bump the minor when the HTTP surface grows or there is a migration, the patch
 for fixes and dependency floors.
 
 Bump `DEFAULT_SERVER_VERSION` in the same PR — the pin is what a fresh
-`stardag self-host up` gets. Self-hosters who would rather track releases as
-they land deploy with `--server-version latest`; see
-[Updating to a new version](docs/docs/how-to/self-host-modal.md#updating-to-a-new-version).
+`stardag self-host up` gets.
 
 ### Dropping support for older SDKs
 

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -110,9 +110,13 @@ stardag self-host connect
 uvx --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
-This applies any new database migrations and redeploys the API + UI. The JWT
-keypair secret is left untouched, so existing sessions and SDK logins survive
-upgrades.
+This applies any new database migrations and redeploys the API + UI. Each
+SDK release pins the server version it was tested against, so `uvx` picking
+up a newer SDK also rolls the server forward; pass
+`--server-version X.Y.Z` (or `latest`) to deploy a specific
+[server release](https://github.com/stardag-dev/stardag/releases). The JWT
+keypair secret is left untouched, so existing sessions and SDK logins
+survive upgrades.
 
 If you deployed with a non-default `--name` or `--server-modal-env`, pass
 the **same** values to `upgrade` (and `status`/`destroy`) — otherwise the
@@ -120,38 +124,6 @@ command looks in the wrong place and reports nothing deployed. In
 particular, a deployment created before these defaults changed (app
 `stardag-server` in Modal's default environment) is upgraded with
 `--name stardag-server --server-modal-env ''`.
-
-### Which server version you get
-
-A new [server release](https://github.com/stardag-dev/stardag/releases) is
-cut after each significant change to the Registry API or the UI, which is
-more often than the SDK's pin moves. Each SDK release pins the server version
-it was **tested against** — that is a known-good pairing, not necessarily the
-newest image — so `uvx` picking up a newer SDK also rolls the server forward,
-just not always to the latest release.
-
-**To track server releases as they land, deploy with `--server-version
-latest`:**
-
-```bash
-uvx --from "stardag[selfhost]" stardag self-host upgrade --server-version latest
-```
-
-The choice is remembered, so later plain `upgrade` runs stay on `latest`.
-Pass `--server-version X.Y.Z` to hold a specific release instead — that is
-also how you get back off `latest`.
-
-!!! note "Confirm what you actually deployed"
-
-    `latest` is a mutable tag, and image builds are cached, so an `upgrade`
-    that changes nothing else may reuse the image already built for that tag
-    rather than pulling a newer one.
-
-    `stardag self-host status` will not tell you: it echoes what you asked
-    for at deploy time, so it just says `latest`. The running release is the
-    one baked into the image, reported by `GET /api/v1/version` on your
-    deployment and shown in the footer of the Settings page. If it has not
-    moved and you expected it to, redeploy with the explicit `X.Y.Z`.
 
 ## Deploying from source (development)
 
@@ -244,8 +216,7 @@ stardag self-host destroy    # stop the Modal app (never touches the database)
 Useful flags for `up` (all prompts have flag equivalents for CI):
 
 - `--server-version X.Y.Z` (or `latest`) — prebuilt server image version to
-  deploy (default: the version this SDK release is tested against; see
-  [Which server version you get](#which-server-version-you-get))
+  deploy (default: the version this SDK release is tested against)
 - `--from-source` — build the image from a local repo checkout instead of
   the prebuilt image (see
   [Deploying from source](#deploying-from-source-development))

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -110,13 +110,9 @@ stardag self-host connect
 uvx --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
-This applies any new database migrations and redeploys the API + UI. Each
-SDK release pins the server version it was tested against, so `uvx` picking
-up a newer SDK also rolls the server forward; pass
-`--server-version X.Y.Z` (or `latest`) to deploy a specific
-[server release](https://github.com/stardag-dev/stardag/releases). The JWT
-keypair secret is left untouched, so existing sessions and SDK logins
-survive upgrades.
+This applies any new database migrations and redeploys the API + UI. The JWT
+keypair secret is left untouched, so existing sessions and SDK logins survive
+upgrades.
 
 If you deployed with a non-default `--name` or `--server-modal-env`, pass
 the **same** values to `upgrade` (and `status`/`destroy`) — otherwise the
@@ -124,6 +120,38 @@ command looks in the wrong place and reports nothing deployed. In
 particular, a deployment created before these defaults changed (app
 `stardag-server` in Modal's default environment) is upgraded with
 `--name stardag-server --server-modal-env ''`.
+
+### Which server version you get
+
+A new [server release](https://github.com/stardag-dev/stardag/releases) is
+cut after each significant change to the Registry API or the UI, which is
+more often than the SDK's pin moves. Each SDK release pins the server version
+it was **tested against** — that is a known-good pairing, not necessarily the
+newest image — so `uvx` picking up a newer SDK also rolls the server forward,
+just not always to the latest release.
+
+**To track server releases as they land, deploy with `--server-version
+latest`:**
+
+```bash
+uvx --from "stardag[selfhost]" stardag self-host upgrade --server-version latest
+```
+
+The choice is remembered, so later plain `upgrade` runs stay on `latest`.
+Pass `--server-version X.Y.Z` to hold a specific release instead — that is
+also how you get back off `latest`.
+
+!!! note "Confirm what you actually deployed"
+
+    `latest` is a mutable tag, and image builds are cached, so an `upgrade`
+    that changes nothing else may reuse the image already built for that tag
+    rather than pulling a newer one.
+
+    `stardag self-host status` will not tell you: it echoes what you asked
+    for at deploy time, so it just says `latest`. The running release is the
+    one baked into the image, reported by `GET /api/v1/version` on your
+    deployment and shown in the footer of the Settings page. If it has not
+    moved and you expected it to, redeploy with the explicit `X.Y.Z`.
 
 ## Deploying from source (development)
 
@@ -216,7 +244,8 @@ stardag self-host destroy    # stop the Modal app (never touches the database)
 Useful flags for `up` (all prompts have flag equivalents for CI):
 
 - `--server-version X.Y.Z` (or `latest`) — prebuilt server image version to
-  deploy (default: the version this SDK release is tested against)
+  deploy (default: the version this SDK release is tested against; see
+  [Which server version you get](#which-server-version-you-get))
 - `--from-source` — build the image from a local repo checkout instead of
   the prebuilt image (see
   [Deploying from source](#deploying-from-source-development))

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -62,7 +62,7 @@ DEFAULT_SERVER_MODAL_ENV = "stardag-host"
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK
 # release time; override per deployment with --server-version.
-DEFAULT_SERVER_VERSION = "0.1.2"
+DEFAULT_SERVER_VERSION = "0.2.0"
 
 # Minimum client interpreter for from-source image builds (stardag-api's
 # requires-python; the image gets the client's version via add_python).


### PR DESCRIPTION
Preparation for a `server-v0.2.0` tag, plus the policy that should stop the
next gap happening. Docs and one constant — no behaviour change.

## The 0.22.0 changelog entries were filed under `[0.21.0]`

The v0.22.0 release commit inserted its SDK and Registry API entries *after*
the `[0.21.0]` heading rather than opening a new section, so `CHANGELOG.md`
has no `[0.22.0]` heading at all. Worse, the inserted block ends with its own
`### Registry API` heading, which left every genuine 0.21.0 SDK bullet after
it sitting under "Registry API".

Split out as `## [0.22.0] — 2026-08-30`. Two checks, both clean:

- the restored `[0.21.0]` section is **byte-identical** to the one at tag
  `v0.21.0`
- the new `[0.22.0]` body is **byte-identical** to what `v0.21.0..v0.22.0`
  added

`RELEASE_NOTES.md` was already correct (it has `## v0.22.0 — A finished task
wakes every build waiting on it`), so this is changelog-only. It matters for
a server release specifically, because the server release notes point readers
at this file's Registry API / UI / Deployment sections to say what changed.

## `DEFAULT_SERVER_VERSION` 0.1.2 → 0.2.0

`server-v0.1.2` is from 2026-08-12 and is 15 commits of `app/` behind main:

- `INTERRUPTED` as a first-class task status and
  `POST /builds/{id}/tasks/{task_id}/interrupt` (0.19.0)
- `POST /builds/{id}/notify` reporting `scheduler_live` (0.21.0)
- `POST /builds/wake-candidates` and the `builds.tick_requested_at` migration
  `97ce4e3cbf32` (0.22.0)
- the `python-jose` → `PyJWT` swap for token auth
- raised security floors on the API's transitive dependencies and the UI's
  build tooling

So a fresh `stardag self-host up` on the v0.22.0 SDK line currently gets a
server that predates the cross-build wake-up endpoints. That degrades
gracefully by design — an older registry answers nothing — but it degrades
*silently*, and the result is a self-hoster who upgraded for cross-build
wake-ups and does not get them.

Minor rather than patch: the HTTP surface grew and there is a schema
migration. Recorded under `[Unreleased]` as an SDK bullet (matching the
0.16.0 precedent) plus a `Deployment` entry saying what the image spans.

## The cadence, written down

`DEV_README.md` gains **"When to cut one"**: after each significant change to
the Registry API or the UI, not in batches. The image is the only route those
changes have to a self-hosted deployment — the hosted service builds from a
commit and always runs the newest API, a self-hoster runs the last `server-v*`
tag — so an unreleased API change reaches nobody else.

The reason it needs saying is that lagging fails *silently*: version skew
degrades gracefully by design, so a stale self-hoster sees no error, just a
feature they upgraded the SDK for quietly not working. `server-v0.1.2` sat 18
days that way, through six SDK releases.

## Deliberately not here: `--server-version latest`

An earlier revision of this PR documented `latest` as the way for
self-hosters to track releases. That meant documenting around two problems
instead of fixing them:

- `latest` is a mutable tag and Modal caches image builds by their
  definition, so an `upgrade` that changes nothing else may reuse the image
  already built for that tag rather than pulling a newer one.
- `self-host status` echoes the version *requested* at deploy time, so a
  deployment on `latest` just reports `latest` — it cannot tell you what is
  actually running.

The fix is to make `latest` a **resolution keyword in the CLI**: resolve it
to the newest `server-vX.Y.Z` at execution time and use that explicit
version for the image ref, the recorded meta and `status`, so no mutable tag
ever reaches Modal. GHCR keeps its `:latest` tag for anyone using it
directly. That is a CLI change rather than release prep, and lands in a
follow-up along with a related bug found while reviewing it —
`_resolve_upgrade_server_version` returns the recorded deployed version
unconditionally, so a plain `upgrade` never rolls a deployment forward.

## Order of operations

`DEFAULT_SERVER_VERSION` now names an image that does not exist yet. After
merge: tag `server-v0.2.0` on the merge commit, let
`publish-server-image.yml` push `ghcr.io/stardag-dev/stardag-server:{0.2.0,latest}`,
then verify an anonymous pull.

## Test plan

- `pytest lib/stardag/tests/test_selfhost` — 67 passed (covers the
  `DEFAULT_SERVER_VERSION` semver guard and the resolution paths that read it)
- `pre-commit run --files <changed>` — prettier, ruff, ruff-format, pyright
  all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)