### PR TITLE
Resolve `--server-version latest` at deploy time; let upgrade roll forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **`--server-version latest` is resolved at deploy time, not deployed as a
+  tag.** `stardag self-host up/upgrade --server-version latest` now asks the
+  GitHub Releases API for the newest `server-vX.Y.Z`, prints what it resolved
+  to, and uses that concrete version for the image reference, the recorded
+  deployment meta and `self-host status`. Previously the literal string
+  reached `modal.Image.from_registry`, where a mutable tag is cached like any
+  other image definition — so an upgrade could silently redeploy the image
+  already built for `:latest`, and nothing afterwards could say which release
+  was running (`status` echoed `latest`). Releases rather than git tags are
+  the source of truth because the release job runs `needs: publish-image`, so
+  a release exists only if the image push succeeded. A deployment recorded as
+  `latest` by an older SDK resolves once on its next upgrade and converts to a
+  pin. GHCR's `:latest` tag is unchanged and still usable directly.
+- **A plain `stardag self-host upgrade` rolls the server version forward
+  again.** `_resolve_upgrade_server_version` returned the recorded deployed
+  version unconditionally, so once a deployment had recorded a version only an
+  explicit `--server-version` could ever move it — a newer SDK's pin was
+  ignored, contrary to what the self-host docs said. It now deploys the newer
+  of the recorded version and `DEFAULT_SERVER_VERSION`, which keeps the
+  anti-downgrade property that motivated the original behaviour (a deployment
+  ahead of this SDK's pin stays where it is) while letting the pin move a
+  deployment that is behind.
+
 - **One arbitrated start method on `RegistryABC`.**
   `task_start_with_limits_aio` is removed; `task_start_claim_aio` gains a
   `claim: bool = True` parameter, so the two orthogonal flags the registry's

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -110,13 +110,40 @@ stardag self-host connect
 uvx --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
-This applies any new database migrations and redeploys the API + UI. Each
-SDK release pins the server version it was tested against, so `uvx` picking
-up a newer SDK also rolls the server forward; pass
-`--server-version X.Y.Z` (or `latest`) to deploy a specific
-[server release](https://github.com/stardag-dev/stardag/releases). The JWT
-keypair secret is left untouched, so existing sessions and SDK logins
-survive upgrades.
+This applies any new database migrations and redeploys the API + UI. The JWT
+keypair secret is left untouched, so existing sessions and SDK logins survive
+upgrades.
+
+### Which server version you get
+
+Each SDK release pins the
+[server release](https://github.com/stardag-dev/stardag/releases) it was
+tested against. A plain `upgrade` deploys **the newer of that pin and the
+version you are already running** — so `uvx` picking up a newer SDK rolls the
+server forward, and an upgrade never quietly moves you backwards onto an
+older server than the one whose migrations have already run.
+
+Two ways to override it:
+
+```bash
+# Deploy a specific release and stay there
+stardag self-host upgrade --server-version 0.2.0
+
+# Deploy whatever the newest published release is right now
+stardag self-host upgrade --server-version latest
+```
+
+`latest` is resolved **when the command runs**, and the concrete version it
+resolves to is what gets deployed and recorded — the command prints
+`Resolved latest to server version 0.2.0`, `self-host status` reports
+`0.2.0`, and a later plain `upgrade` treats it as the pinned version it is.
+Nothing downstream deploys a moving tag, so what is running is always
+something you can name.
+
+New server releases are cut after each significant change to the Registry
+API or the UI, which is more often than the SDK's pin moves. If you want
+those as they land, `--server-version latest` each time is the way; if you
+would rather move in step with the SDK, plain `upgrade` already does that.
 
 If you deployed with a non-default `--name` or `--server-modal-env`, pass
 the **same** values to `upgrade` (and `status`/`destroy`) — otherwise the
@@ -215,8 +242,11 @@ stardag self-host destroy    # stop the Modal app (never touches the database)
 
 Useful flags for `up` (all prompts have flag equivalents for CI):
 
-- `--server-version X.Y.Z` (or `latest`) — prebuilt server image version to
-  deploy (default: the version this SDK release is tested against)
+- `--server-version X.Y.Z` — prebuilt server image version to deploy
+  (default: the version this SDK release is tested against). `latest`
+  resolves to the newest published release at deploy time and deploys that
+  version explicitly; see
+  [Which server version you get](#which-server-version-you-get)
 - `--from-source` — build the image from a local repo checkout instead of
   the prebuilt image (see
   [Deploying from source](#deploying-from-source-development))

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -322,9 +322,21 @@ def _latest_released_server_version() -> str:
         )
         raise typer.Exit(1) from exc
 
+    if not isinstance(releases, list):
+        # raise_for_status catches the usual failures, but a 200 carrying
+        # something other than the release array must still exit cleanly
+        # rather than crash on the first .get().
+        error_console.print(
+            f"Could not resolve --server-version {LATEST_VERSION}: unexpected "
+            "response from the GitHub releases API. Pass an explicit "
+            "--server-version X.Y.Z instead."
+        )
+        raise typer.Exit(1)
+
     versions = [
         parsed
         for release in releases
+        if isinstance(release, dict)
         if not release.get("draft") and not release.get("prerelease")
         for tag in [release.get("tag_name") or ""]
         if tag.startswith(SERVER_TAG_PREFIX)

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -267,6 +267,12 @@ def _resolve_keep_warm(
 # Sentinel recorded as the deployed "version" for --from-source deploys.
 FROM_SOURCE_VERSION = "source"
 
+# `--server-version latest` is a keyword resolved at CLI time, not a tag we
+# deploy. See _resolve_version_keyword.
+LATEST_VERSION = "latest"
+SERVER_TAG_PREFIX = "server-v"
+SERVER_RELEASES_API = "https://api.github.com/repos/stardag-dev/stardag/releases"
+
 
 def _parse_semver(version: str) -> tuple[int, int, int] | None:
     """Parse 'X.Y.Z' into a comparable tuple; None for anything else."""
@@ -278,6 +284,83 @@ def _parse_semver(version: str) -> tuple[int, int, int] | None:
     except ValueError:
         return None
     return major, minor, patch
+
+
+def _latest_released_server_version() -> str:
+    """The newest published server release, as a bare ``X.Y.Z``.
+
+    Read from the GitHub *Releases* API rather than the tags API on purpose:
+    the release job in ``publish-server-image.yml`` runs ``needs:
+    publish-image``, so a ``server-vX.Y.Z`` release exists only if the image
+    push succeeded. A tag can outlive a failed build; a release cannot.
+    """
+    import httpx
+
+    headers = {"Accept": "application/vnd.github+json"}
+    # Unauthenticated GitHub allows 60 requests/hour per IP, which is ample
+    # for a CLI - but honour a token when one is around, so a shared-egress
+    # CI runner does not trip over someone else's budget.
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = httpx.get(
+            SERVER_RELEASES_API,
+            params={"per_page": 100},
+            headers=headers,
+            timeout=30.0,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        releases = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        error_console.print(
+            f"Could not resolve --server-version {LATEST_VERSION}: {exc}\n"
+            "Pass an explicit --server-version X.Y.Z instead - see "
+            "https://github.com/stardag-dev/stardag/releases"
+        )
+        raise typer.Exit(1) from exc
+
+    versions = [
+        parsed
+        for release in releases
+        if not release.get("draft") and not release.get("prerelease")
+        for tag in [release.get("tag_name") or ""]
+        if tag.startswith(SERVER_TAG_PREFIX)
+        for parsed in [_parse_semver(tag[len(SERVER_TAG_PREFIX) :])]
+        if parsed is not None
+    ]
+    if not versions:
+        error_console.print(
+            f"Could not resolve --server-version {LATEST_VERSION}: no "
+            f"{SERVER_TAG_PREFIX}X.Y.Z releases found. Pass an explicit "
+            "--server-version X.Y.Z instead."
+        )
+        raise typer.Exit(1)
+
+    return ".".join(str(part) for part in max(versions))
+
+
+def _resolve_version_keyword(server_version: str | None) -> str | None:
+    """Resolve the ``latest`` keyword to the concrete version it means now.
+
+    Everything downstream - the image reference, the recorded deployment
+    meta, ``status`` - then works in explicit ``X.Y.Z`` terms. Deploying the
+    mutable ``:latest`` tag instead would be cached like any other image
+    definition, so an upgrade could silently redeploy the image already
+    built for that tag, and nothing afterwards could say which release is
+    actually running. GHCR's ``:latest`` tag is unaffected and stays usable
+    directly.
+    """
+    if server_version != LATEST_VERSION:
+        return server_version
+    resolved = _latest_released_server_version()
+    console.print(
+        f"Resolved [bold]{LATEST_VERSION}[/bold] to server version "
+        f"[bold]{resolved}[/bold]."
+    )
+    return resolved
 
 
 def _record_deployed_server_version(
@@ -318,12 +401,17 @@ def _resolve_upgrade_server_version(
 ) -> str:
     """Server version for prebuilt-image `upgrade` runs.
 
-    Resolution order: explicit --server-version flag > recorded deployed
-    version > DEFAULT_SERVER_VERSION. Defaulting to the recorded version
-    means a plain `upgrade` never silently downgrades a deployment running
-    a version newer than this SDK's default (whose migrations may have
-    advanced the DB schema past what the default server release knows).
-    An explicitly passed older version wins, with a warning.
+    An explicit --server-version wins outright (with a warning if it is a
+    downgrade). Otherwise a plain `upgrade` takes the *newer* of the
+    recorded deployed version and DEFAULT_SERVER_VERSION:
+
+    - the recorded version wins when it is ahead, so an upgrade never
+      silently downgrades a deployment whose migrations may have advanced
+      the DB schema past what this SDK's default server release knows;
+    - the SDK's default wins when it is ahead, so `uvx` picking up a newer
+      SDK actually rolls the server forward. Returning the recorded version
+      unconditionally meant a deployment froze at whatever it first
+      recorded and only an explicit flag could ever move it.
     """
     deployed = _deployed_server_version(app_name, environment_name)
     if explicit is not None:
@@ -348,7 +436,20 @@ def _resolve_upgrade_server_version(
             "to keep building from a local checkout)."
         )
         return DEFAULT_SERVER_VERSION
+    if deployed == LATEST_VERSION:
+        # Recorded by an SDK that deployed the mutable tag itself. Resolve it
+        # once; the concrete version is what gets recorded, so the deployment
+        # converts to a pin and stops depending on the tag.
+        return _resolve_version_keyword(LATEST_VERSION) or DEFAULT_SERVER_VERSION
     if deployed is not None:
+        deployed_semver = _parse_semver(deployed)
+        default_semver = _parse_semver(DEFAULT_SERVER_VERSION)
+        if (
+            deployed_semver is not None
+            and default_semver is not None
+            and default_semver > deployed_semver
+        ):
+            return DEFAULT_SERVER_VERSION
         return deployed
     return DEFAULT_SERVER_VERSION
 
@@ -612,7 +713,8 @@ def up(
     server_version: str | None = typer.Option(
         None,
         "--server-version",
-        help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
+        help="Prebuilt server image version to deploy: X.Y.Z, or 'latest' "
+        "to resolve the newest published server release at deploy time "
         f"(default: {DEFAULT_SERVER_VERSION}, the version this SDK release "
         "is tested against)",
     ),
@@ -777,6 +879,7 @@ def up(
     target root, and a local SDK registry + profile.
     """
     interactive = not yes
+    server_version = _resolve_version_keyword(server_version)
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
@@ -1048,8 +1151,9 @@ def upgrade(
     server_version: str | None = typer.Option(
         None,
         "--server-version",
-        help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
-        "(default: the currently deployed version, falling back to "
+        help="Prebuilt server image version to deploy: X.Y.Z, or 'latest' "
+        "to resolve the newest published server release at deploy time "
+        "(default: the newer of the currently deployed version and "
         f"{DEFAULT_SERVER_VERSION}, the version this SDK release is tested "
         "against)",
     ),
@@ -1081,6 +1185,7 @@ def upgrade(
     ),
 ):
     """Update the deployment: apply DB migrations and redeploy."""
+    server_version = _resolve_version_keyword(server_version)
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -70,7 +70,13 @@ MIN_IMAGE_PYTHON = (3, 10)
 
 
 def server_image_ref(version: str) -> str:
-    """Full image reference for a released server version (or "latest")."""
+    """Full image reference for a released server version.
+
+    Callers pass a concrete ``X.Y.Z``: the CLI resolves ``latest`` to one
+    before it gets here, so no mutable tag ends up in a Modal image
+    definition. ``"latest"`` still produces a valid reference for anyone
+    using the repo directly.
+    """
     return f"{SERVER_IMAGE_REPO}:{version}"
 
 

--- a/lib/stardag/tests/test_selfhost/test_cli_config.py
+++ b/lib/stardag/tests/test_selfhost/test_cli_config.py
@@ -7,17 +7,22 @@ import pytest
 pytest.importorskip("modal")
 pytest.importorskip("cryptography")
 
+import typer  # noqa: E402
+
 from stardag._cli.selfhost import (  # noqa: E402
     FROM_SOURCE_VERSION,
+    LATEST_VERSION,
     MAX_ADMIN_PASSWORD_BYTES,
     MIN_ADMIN_PASSWORD_CHARS,
     _admin_password_error,
     _build_config_env,
     _generate_jwt_keypair,
+    _latest_released_server_version,
     _provided_config_flags,
     _record_deployed_server_version,
     _resolve_keep_warm,
     _resolve_upgrade_server_version,
+    _resolve_version_keyword,
 )
 from stardag.selfhost._modal_app import DEFAULT_SERVER_VERSION  # noqa: E402
 from stardag.selfhost._modal_app import find_repo_root  # noqa: E402
@@ -229,8 +234,9 @@ def test_upgrade_version_explicit_flag_wins(monkeypatch: pytest.MonkeyPatch):
     _patch_meta_dict(monkeypatch, store)
     # Explicit newer version: no warning path, explicit wins
     assert _resolve_upgrade_server_version("myapp", "0.3.0") == "0.3.0"
-    # Explicit 'latest' (not comparable): explicit wins
-    assert _resolve_upgrade_server_version("myapp", "latest") == "latest"
+    # An explicit version is passed through verbatim. The commands resolve
+    # the `latest` keyword before calling this, so it only ever sees X.Y.Z.
+    assert _resolve_upgrade_server_version("myapp", "0.2.1") == "0.2.1"
 
 
 def test_upgrade_version_explicit_downgrade_warns_but_proceeds(
@@ -253,6 +259,145 @@ def test_upgrade_version_from_source_deploy_uses_default(
     store: dict = {"server_version": FROM_SOURCE_VERSION}
     _patch_meta_dict(monkeypatch, store)
     assert _resolve_upgrade_server_version("myapp", None) == DEFAULT_SERVER_VERSION
+
+
+# --- `latest` resolution ----------------------------------------------------
+
+
+def _patch_releases(monkeypatch: pytest.MonkeyPatch, payload) -> dict:
+    """Patch httpx.get to answer the GitHub releases call with `payload`."""
+    import httpx
+
+    captured: dict = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return payload
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return FakeResponse()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    return captured
+
+
+def test_latest_released_server_version_picks_highest_semver(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured = _patch_releases(
+        monkeypatch,
+        [
+            {"tag_name": "server-v0.2.0"},
+            {"tag_name": "server-v0.10.0"},
+            {"tag_name": "server-v0.9.3"},
+        ],
+    )
+    # 0.10.0 > 0.9.3 numerically, not lexically
+    assert _latest_released_server_version() == "0.10.0"
+    assert captured["url"].endswith("/repos/stardag-dev/stardag/releases")
+
+
+def test_latest_released_server_version_ignores_other_tags(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_releases(
+        monkeypatch,
+        [
+            {"tag_name": "v0.22.0"},  # SDK release, not the server
+            {"tag_name": "server-v0.1.2"},
+            {"tag_name": "server-vnonsense"},
+            {"tag_name": "server-v0.2.0", "draft": True},
+            {"tag_name": "server-v0.3.0", "prerelease": True},
+        ],
+    )
+    assert _latest_released_server_version() == "0.1.2"
+
+
+def test_latest_released_server_version_no_releases_exits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_releases(monkeypatch, [{"tag_name": "v0.22.0"}])
+    with pytest.raises(typer.Exit):
+        _latest_released_server_version()
+
+
+def test_latest_released_server_version_http_error_exits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import httpx
+
+    def fake_get(url, **kwargs):
+        raise httpx.ConnectError("no network")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    with pytest.raises(typer.Exit):
+        _latest_released_server_version()
+
+
+def test_latest_released_server_version_sends_token_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_example")
+    captured = _patch_releases(monkeypatch, [{"tag_name": "server-v0.2.0"}])
+    assert _latest_released_server_version() == "0.2.0"
+    assert captured["kwargs"]["headers"]["Authorization"] == "Bearer ghp_example"
+
+
+def test_resolve_version_keyword_passes_through(monkeypatch: pytest.MonkeyPatch):
+    # No network call for anything but the keyword
+    import httpx
+
+    def explode(*args, **kwargs):
+        raise AssertionError("should not have called the releases API")
+
+    monkeypatch.setattr(httpx, "get", explode)
+    assert _resolve_version_keyword(None) is None
+    assert _resolve_version_keyword("0.2.0") == "0.2.0"
+
+
+def test_resolve_version_keyword_resolves_latest(monkeypatch: pytest.MonkeyPatch):
+    _patch_releases(monkeypatch, [{"tag_name": "server-v0.4.1"}])
+    assert _resolve_version_keyword(LATEST_VERSION) == "0.4.1"
+
+
+# --- upgrade rolls forward as well as refusing to roll back -----------------
+
+
+def test_upgrade_version_rolls_forward_to_sdk_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The SDK's tested pin wins when it is ahead of what is deployed.
+
+    Returning the recorded version unconditionally froze a deployment at
+    whatever it first recorded, so a plain `upgrade` could never move it.
+    """
+    store: dict = {"server_version": "0.0.1"}
+    _patch_meta_dict(monkeypatch, store)
+    assert _resolve_upgrade_server_version("myapp", None) == DEFAULT_SERVER_VERSION
+
+
+def test_upgrade_version_recorded_latest_resolves_to_concrete(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A deployment recorded as `latest` by an older SDK converts to a pin."""
+    store: dict = {"server_version": LATEST_VERSION}
+    _patch_meta_dict(monkeypatch, store)
+    _patch_releases(monkeypatch, [{"tag_name": "server-v0.5.0"}])
+    assert _resolve_upgrade_server_version("myapp", None) == "0.5.0"
+
+
+def test_upgrade_version_unparseable_recorded_version_is_kept(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An unrecognised recorded value is left alone rather than guessed at."""
+    store: dict = {"server_version": "some-custom-tag"}
+    _patch_meta_dict(monkeypatch, store)
+    assert _resolve_upgrade_server_version("myapp", None) == "some-custom-tag"
 
 
 def test_generate_jwt_keypair_pem():

--- a/lib/stardag/tests/test_selfhost/test_cli_config.py
+++ b/lib/stardag/tests/test_selfhost/test_cli_config.py
@@ -326,6 +326,22 @@ def test_latest_released_server_version_no_releases_exits(
         _latest_released_server_version()
 
 
+def test_latest_released_server_version_non_list_payload_exits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A 200 carrying an error object must exit cleanly, not AttributeError."""
+    _patch_releases(monkeypatch, {"message": "API rate limit exceeded"})
+    with pytest.raises(typer.Exit):
+        _latest_released_server_version()
+
+
+def test_latest_released_server_version_skips_non_dict_entries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_releases(monkeypatch, ["nonsense", {"tag_name": "server-v0.2.0"}])
+    assert _latest_released_server_version() == "0.2.0"
+
+
 def test_latest_released_server_version_http_error_exits(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
Follow-up to #293, which deliberately left `latest` guidance out because
documenting it would have meant documenting around two problems rather than
fixing them. This fixes them.

## `latest` is a keyword, not a tag we deploy

The literal string used to reach `modal.Image.from_registry`, where a mutable
tag is cached like any other image definition — so an `upgrade` that changed
nothing else could silently redeploy the image already built for `:latest`.
And nothing afterwards could tell you which release was running: `self-host
status` echoes the version *requested* at deploy time, so a deployment on
`latest` just reported `latest`.

It is now resolved when the command runs. The concrete version is what
reaches the image reference, the recorded deployment meta, and `status`:

```
$ stardag self-host upgrade --server-version latest
Resolved latest to server version 0.2.0
...
$ stardag self-host status
  Server version: 0.2.0
```

GHCR's `:latest` tag is untouched and stays usable directly — a mutable tag
on a container registry is standard and fine, the CLI just should not be the
thing depending on it.

**Releases, not tags, are the source of truth.** `publish-server-image.yml`'s
release job runs `needs: publish-image`, so a `server-vX.Y.Z` GitHub Release
exists only if the image push succeeded. A git tag can outlive a failed
build; a release cannot.

**Resolution failure is loud** — it tells you to pass an explicit `X.Y.Z`
rather than quietly falling back to the pin. A silent substitution is the
exact failure mode this change is about.

**Migration:** a deployment recorded as `latest` by an older SDK resolves
once on its next upgrade and converts to a pin, so it self-heals rather than
staying on a moving tag.

## A plain `upgrade` rolls the version forward again

Found while reviewing the above. `_resolve_upgrade_server_version` was:

```python
if deployed is not None:
    return deployed          # ← always wins
return DEFAULT_SERVER_VERSION
```

So once a deployment had recorded a version, **only an explicit
`--server-version` could ever move it.** A newer SDK's pin was ignored —
directly contradicting the self-host docs, which said "`uvx` picking up a
newer SDK also rolls the server forward". That has been false for every
existing deployment.

It now deploys the newer of the recorded version and
`DEFAULT_SERVER_VERSION`. That keeps the anti-downgrade property the original
behaviour was written for (a deployment ahead of this SDK's pin stays put,
because its migrations may have advanced the schema) while letting the pin
move a deployment that is behind.

The existing test (`test_upgrade_version_defaults_to_deployed`) only covered
a recorded version *ahead* of the default, which is why the other direction
went unnoticed.

## Docs

`docs/how-to/self-host-modal.md` gains "Which server version you get",
describing what actually happens now: plain `upgrade` takes the newer of the
pin and what you run; `--server-version X.Y.Z` holds a release;
`--server-version latest` takes the newest published one, resolved and
recorded concretely.

## Test plan

- `pytest lib/stardag/tests/test_selfhost` — 77 passed (10 new: semver
  ordering across `0.10.0`/`0.9.3`, draft/prerelease/foreign-tag filtering,
  HTTP-error and empty-result exits, `GITHUB_TOKEN` header, keyword
  pass-through making no network call, roll-forward, recorded-`latest`
  migration, unparseable recorded value left alone)
- `pytest lib/stardag/tests` — 1437 passed; the 17 errors are the live Modal
  tier failing on a local client-3.14/image-3.12 mismatch, unrelated and
  covered by its own CI job
- `pre-commit run --files <changed>` — prettier, ruff, ruff-format, pyright
  all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)