### PR TITLE
Fail the build when a uv.lock has drifted from its pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      # Needed by the uv-lock-check hook. The pyright hooks also shell out to
+      # uv, but they are skipped below, so this job had no uv until now.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,17 @@ repos:
   # Pyright hooks - one per Python package, each using its own .venv
   - repo: local
     hooks:
+      # Lockfile freshness. Nothing else catches drift: tox runs plain
+      # `uv sync`, which silently re-resolves a stale lock, so CI ends up
+      # testing a resolution nobody committed. One hook covers every uv
+      # project — the script discovers them from the committed lockfiles.
+      - id: uv-lock-check
+        name: uv lock --check (all uv projects)
+        entry: scripts/check-uv-locks.sh
+        language: system
+        files: (^|/)(pyproject\.toml|uv\.lock)$
+        pass_filenames: false
+        verbose: true
       - id: pyright-stardag
         name: pyright (lib/stardag)
         entry: bash -c 'cd lib/stardag && uv sync --all-extras && uv run pyright src tests'

--- a/lib/stardag-examples/standalone/stardag-modal/uv.lock
+++ b/lib/stardag-examples/standalone/stardag-modal/uv.lock
@@ -837,7 +837,7 @@ wheels = [
 
 [[package]]
 name = "stardag"
-version = "0.18.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -850,9 +850,9 @@ dependencies = [
     { name = "typer" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/4e/6849bacaf9f622b93f50e196493912b05d953efff142e1648834232aef68/stardag-0.18.0.tar.gz", hash = "sha256:a8781e97a13adc8cee6518589b3c7cc4e7e3b472481992c715a8f8bf4741d1c9", size = 797703, upload-time = "2026-08-11T17:50:36.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/e7/1cb3d3ba8ba6980553e7de261129cc80436c8a722fb28a4210e270024fa0/stardag-0.22.0.tar.gz", hash = "sha256:4ae0284a809df6b8b6e435c946b2430c507e78008e35f1a91882e6bd62a951e1", size = 895149, upload-time = "2026-08-30T01:14:24.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/a9/d1828c89a4e773c3fbe66c531c4994123719bdc90d905583c154c0fd0200/stardag-0.18.0-py3-none-any.whl", hash = "sha256:dedaa1eec217e50efc064dc3c9c89f7792d3d633d226fe3e48a6a40414aac9fe", size = 371096, upload-time = "2026-08-11T17:50:34.709Z" },
+    { url = "https://files.pythonhosted.org/packages/44/49/331823fbc7fe31f1f61dd8b63b1d49355dbce6488b87fb517648198af25f/stardag-0.22.0-py3-none-any.whl", hash = "sha256:84db7d8418c50b3683a88b2387db22d372498b45ac0b9399b3c6659ac8a68733", size = 428730, upload-time = "2026-08-30T01:14:22.915Z" },
 ]
 
 [package.optional-dependencies]
@@ -872,7 +872,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "modal" },
-    { name = "stardag", extras = ["modal"], specifier = ">=0.3.0" },
+    { name = "stardag", extras = ["modal"], specifier = ">=0.20.0" },
 ]
 
 [[package]]

--- a/scripts/check-uv-locks.sh
+++ b/scripts/check-uv-locks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Verify every committed uv.lock still matches its pyproject.toml.
+#
+# Nothing else says so. tox runs plain `uv sync`, which silently re-resolves a
+# stale lock, so drift never fails a build — it just means CI tested a
+# resolution nobody committed. `uv lock --check` is the explicit signal.
+#
+# Projects are discovered from the committed lockfiles rather than listed here,
+# so a new uv project is covered the day it lands. A hand-maintained list is
+# exactly what went stale last time.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "check-uv-locks: uv is not installed (see https://docs.astral.sh/uv/)" >&2
+    exit 1
+fi
+
+# Deliberately not `set -e`: check every project and report all the stale ones,
+# rather than aborting at the first and hiding the rest.
+status=0
+while IFS= read -r lock; do
+    project="$(dirname "$lock")"
+    if uv lock --project "$project" --check >/dev/null 2>&1; then
+        printf 'ok     %s\n' "$project"
+    else
+        printf 'STALE  %s\n' "$project"
+        status=1
+    fi
+done < <(git ls-files | grep -E '(^|/)uv\.lock$' | sort)
+
+if [ "$status" -ne 0 ]; then
+    cat >&2 <<'MSG'
+
+A uv.lock no longer matches its pyproject.toml. Run `uv lock` in each
+directory marked STALE above and commit the result.
+MSG
+fi
+
+exit "$status"

--- a/scripts/check-uv-locks.sh
+++ b/scripts/check-uv-locks.sh
@@ -24,10 +24,15 @@ fi
 status=0
 while IFS= read -r lock; do
     project="$(dirname "$lock")"
-    if uv lock --project "$project" --check >/dev/null 2>&1; then
+    if output="$(uv lock --project "$project" --check 2>&1)"; then
         printf 'ok     %s\n' "$project"
     else
         printf 'STALE  %s\n' "$project"
+        # Keep uv's own message. `--check` fails for reasons other than drift
+        # too — a malformed manifest, an unresolvable requirement, a uv
+        # internal error — and swallowing those makes every one of them read
+        # as drift, sending the reader to `uv lock`, which is the wrong fix.
+        printf '%s\n' "$output" | sed 's/^/       /'
         status=1
     fi
 done < <(git ls-files | grep -E '(^|/)uv\.lock$' | sort)


### PR DESCRIPTION
Closes STA-8.

## Problem

Committed `uv.lock` files were never checked against their manifests. tox
runs plain `uv sync --active --all-extras` — no `--frozen`, no `--locked`
— so when a lock is stale uv silently re-resolves, CI tests a resolution
nobody committed, and nothing in the output mentions the difference.

It landed twice in one week, both from the same dependabot batch:
`lib/stardag/uv.lock` (fixed in #279) and
`lib/stardag-examples/standalone/stardag-modal/uv.lock`, which is stale
on `main` right now — #275 bumped that manifest to
`stardag[modal]>=0.20.0` and left the lock pinning **0.18.0**, with a
`requires-dist` entry still reading `>=0.3.0`. Unsatisfiable against its
own manifest.

## What

- `scripts/check-uv-locks.sh` — runs `uv lock --check` per project.
- A `uv-lock-check` pre-commit hook that calls it.
- `astral-sh/setup-uv@v7` in the Lint job, which had no uv until now (the
  pyright hooks shell out to it, but they are skipped there).
- Regenerates the stale `stardag-modal` lock.

Two deliberate choices in the script:

**Projects are discovered, not listed.** It reads the committed lockfiles
out of `git ls-files`, so a new uv project is covered the day it lands. A
hand-maintained list is precisely the thing that went stale last time.

**No `set -e`.** It checks every project and reports all the stale ones,
rather than aborting at the first and hiding the rest — which matters,
per the verification below.

## Why a hook rather than `--frozen` in tox

`--frozen` would also close the gap, but it converts drift into a
confusing failure part-way through a test run. The honest signal is "the
lockfile is out of date", and the explicit check says that. It also lands
inside the existing Lint job, which runs `--all-files`, so it fires
regardless of which paths a PR touched — and it catches drift locally
before a push.

## Verification — the check is not vacuous

Against `main` it flags the known-stale project, and passes once
regenerated:

```
ok     app/stardag-api
ok     docs
ok     integration-tests
STALE  lib/stardag-examples/standalone/stardag-modal
ok     lib/stardag-examples
ok     lib/stardag
```

More usefully, drifting `lib/stardag/pyproject.toml` by hand (bumping the
`httpx` floor) reports **three** projects stale at once:

```
STALE  docs
STALE  integration-tests
STALE  lib/stardag
```

That is exactly the transitive case #270 and #271 merged green — a
constraint edited in `lib/stardag` invalidating its consumers' locks as
well as its own — and it is why the script reports all failures instead
of stopping at the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)