### PR TITLE
Declare the Python projects under `uv`, the ecosystem dependabot uses

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,18 @@
 # grouped into one PR per ecosystem per week to avoid a flood of single-dep PRs.
 #
 # Ecosystems:
-#   - pip: all Python projects (uv.lock is detected by the pip ecosystem)
+#   - uv: all Python projects. Every one is a uv project with a committed
+#     uv.lock, and dependabot's uv updater reads pyproject.toml and uv.lock
+#     natively. This used to say `pip`, which is what let the uv updater run
+#     outside the group below — see the note at the end of this file.
 #   - npm: the UI and the AWS CDK tooling
 #   - github-actions: workflow action pins
+#
+# `directory`/`directories` take no glob patterns, so every project is listed
+# explicitly. A new Python project needs a line here or dependabot ignores it.
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directories:
       - "/app/stardag-api"
       - "/lib/stardag"
@@ -46,3 +52,19 @@ updates:
       actions:
         patterns:
           - "*"
+# Why `uv` and not `pip`
+#
+# These six directories were declared under `pip` and the group still did not
+# apply to all of them. The branch names show it: the cryptography bump landed
+# as `dependabot/uv/docs/cryptography-gte-50.0.0` and
+# `dependabot/uv/integration-tests/cryptography-gte-50.0.0` — the `uv`
+# updater, and no `python-<hash>` group suffix — while the standalone Modal
+# example came through as `dependabot/pip/.../python-f0b66d50f1`, grouped.
+# One dependency, two ungrouped PRs, which is the exact flood the group exists
+# to prevent.
+#
+# It also explains a stale lockfile. Scoped to `/docs`, dependabot edited the
+# constraint where it is declared — `lib/stardag/pyproject.toml` — and
+# regenerated only `/docs`'s lock, leaving `lib/stardag/uv.lock` behind.
+# Declaring each project under the ecosystem dependabot actually routes it to
+# is what gets its own lock refreshed by the bump that changes its manifest.


### PR DESCRIPTION
Closes STA-10.

## Problem

`.github/dependabot.yml` declared six uv projects under
`package-ecosystem: "pip"`, with a `python` group matching `*`. The group
did not reach all of them.

The branch names are the evidence:

```
dependabot/uv/docs/cryptography-gte-50.0.0                     ← uv, ungrouped
dependabot/uv/integration-tests/cryptography-gte-50.0.0        ← uv, ungrouped
dependabot/pip/lib/…/standalone/…/python-f0b66d50f1            ← pip, grouped
```

The `python-<hash>` suffix is the group. Two of the three have none — so
one dependency produced two separate ungrouped PRs, one per directory,
which is precisely the flood the group was configured to prevent.

## Why it is not cosmetic

It is the root cause of the stale lockfile #296 fixes. Scoped to `/docs`,
dependabot edited the constraint where it is *declared* —
`lib/stardag/pyproject.toml` — then regenerated only `/docs`'s lock.
`lib/stardag/uv.lock` kept the old floor and merged green.

Declaring each project under the ecosystem dependabot actually routes it
to is what makes its own lock get refreshed by the bump that changes its
manifest. #296 adds the guard that catches it when this fails; this PR
addresses why it happened.

## What

- `package-ecosystem: "pip"` → `"uv"` for the six Python projects.
  Dependabot's uv updater has been [GA since March
  2025](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/)
  and reads `pyproject.toml` and `uv.lock` natively, so nothing is left
  that wants the pip updater.
- Comments rewritten to describe current behaviour. The old one claimed
  "uv.lock is detected by the pip ecosystem", which is what the branch
  names above disprove.
- Recorded that neither `directory` nor `directories` accepts a glob, so
  a new Python project must be listed by hand or dependabot ignores it —
  a quiet failure mode worth naming in the file.

The directory list, schedule, PR limit and group are otherwise unchanged.

## Verification

Config parses and resolves to the intended shape:

```
uv             -> 6 directories | groups: ['python'] | limit: 10
npm            -> 2 directories | groups: ['javascript'] | limit: 10
github-actions -> /             | groups: ['actions']
```

**What cannot be verified before merge:** whether all six directories now
produce grouped updates. That needs a real cycle, and dependabot only
re-evaluates the config once it is on the default branch. Pushing this
does trigger a re-run, so it should be observable shortly after merge
rather than a week later. STA-10 stays open until then — the observation
is the last box on it.

Note `/app/stardag-api`, `/lib/stardag` and `/lib/stardag-examples` have
never produced a version-update PR under the old config. That may simply
mean nothing was outdated; the post-merge cycle is what distinguishes
that from the entry doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)