### PR TITLE
Split dependabot groups so one bad major cannot block the safe updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,11 +47,16 @@ updates:
   # They share no dependency purpose — the UI and the CDK tooling — so there is
   # nothing to gain from a common PR and something to lose: a break in either
   # blocked the other. #276 was one PR across both.
+  #
+  # The limit is 5 each rather than 10, so the npm total stays at the 10 it was
+  # before the split instead of quietly doubling. Majors now arrive
+  # individually, so the cap does real work; raise it if majors start queueing
+  # behind each other, which would be the same blocking problem in miniature.
   - package-ecosystem: "npm"
     directory: "/app/stardag-ui"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       stardag-ui-minor-patch:
         patterns:
@@ -64,7 +69,7 @@ updates:
     directory: "/infra/aws-cdk"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       aws-cdk-minor-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,22 +28,54 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      python:
+      # Minor and patch only. Majors arrive one PR per package, so a single
+      # unresolvable one cannot hold the safe updates hostage.
+      #
+      # These six stay in ONE entry on purpose, unlike npm below. They share
+      # path dependencies: a constraint edited in lib/stardag's manifest
+      # invalidates the locks of /docs and /integration-tests too, and one PR
+      # that carries the manifest and every affected lock together is exactly
+      # what stops a lock being left behind.
+      python-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  # The two npm directories get an entry each, unlike the uv projects above.
+  # They share no dependency purpose — the UI and the CDK tooling — so there is
+  # nothing to gain from a common PR and something to lose: a break in either
+  # blocked the other. #276 was one PR across both.
   - package-ecosystem: "npm"
-    directories:
-      - "/app/stardag-ui"
-      - "/infra/aws-cdk"
+    directory: "/app/stardag-ui"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      javascript:
+      stardag-ui-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  - package-ecosystem: "npm"
+    directory: "/infra/aws-cdk"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      aws-cdk-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Deliberately left as one all-update-types group. Action pins are written
+  # `@v7`, so almost every bump reads as a major — a minor/patch split here
+  # would turn one tidy PR into a stream of individual ones for no benefit.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Closes STA-11.

> **Stacked on #298** (STA-10), which touches the same file. Base is that
> branch, so the diff here is only the grouping change; GitHub will
> retarget to `main` when #298 merges.

## Problem

Every group matched `*` with no update-type split. For npm that meant one
weekly PR across **34 packages, 2 directories and ~10 majors**.

#276 hit both failure modes at once:

**All-or-nothing.** `typescript` went to `~7.0.2`, which no
`typescript-eslint` release supports (8.68.0, its latest, still peers at
`>=4.8.4 <6.1.0`). `npm ci` aborted with `ERESOLVE`, so all four frontend
jobs died before running anything. 31 of the 34 updates were fine and
none could land until someone did the analysis by hand.

**Not reviewable.** eslint 9→10, vite 7→8, jsdom 27→30, TypeScript 5.9→7,
`react-resizable-panels` 3→4, `@dagrejs/dagre` 1→3 and more, in one diff,
with the manifest changes buried in two regenerated lockfiles. Three
needed code migrations rather than a version bump, and nothing in the PR
distinguished those from the trivial ones.

## What

Groups are now **minor/patch only**, so majors arrive one PR per package
— small enough to judge, and one failing blocks nothing else.

The three ecosystems are then split differently, on purpose. That
asymmetry is the substance of this PR, so it is spelled out in the file
itself:

| Ecosystem | Shape | Why |
| --- | --- | --- |
| `npm` | one entry **per directory** | The UI and the CDK tooling share no dependency purpose. A common PR buys nothing and costs the coupling #276 demonstrated. |
| `uv` | one entry across **all six** | They share path dependencies. A constraint edited in `lib/stardag`'s manifest invalidates `/docs` and `/integration-tests` locks too, and one PR carrying the manifest *and* every affected lock is what stops a lock being left behind. Splitting per directory would rebuild the exact problem #296 and #298 are fixing. |
| `github-actions` | left whole, all update types | Pins are written `@v7`, so nearly every bump reads as a major. A minor/patch group here turns one tidy PR into a stream of individual ones for no benefit. |

Per-directory npm entries are only worth doing now that `infra/aws-cdk`
has a CI job at all (#297) — before that, its PRs were unverified either
way.

## Verification

Config parses and resolves to the intended shape:

```
uv              6 directories     group=python-minor-patch      types=[minor, patch]
npm             /app/stardag-ui   group=stardag-ui-minor-patch  types=[minor, patch]
npm             /infra/aws-cdk    group=aws-cdk-minor-patch     types=[minor, patch]
github-actions  /                 group=actions                 types=ALL
```

**What cannot be verified before merge:** the actual PR shapes. Dependabot
only re-evaluates the config once it is on the default branch, so the last
box on STA-11 — one observed cycle — stays open until then. Pushing a
config change does trigger a re-run, so it should be visible shortly after
merge rather than a week later.

## Note

This does not fix the three deferred frontend migrations that make the
current `javascript` group PR fail (`react-resizable-panels` v4,
`eslint-plugin-react-hooks` 7.1's 33 errors, TypeScript 7 blocked
upstream). It stops them from blocking everything else, which is the point
— those three will now arrive as three individual major PRs that can sit
until someone does the migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)