### PR TITLE
BuildTaskStore: async variants, used by the scheduler tick's task loading

### DIFF
--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -1700,7 +1700,7 @@ async def _load_task(
     ``rehydrate.py``, which stays a pure reconstruction primitive with no
     notion of how its classes got imported.
     """
-    task = task_store.load_task(task_id)
+    task = await task_store.load_task_aio(task_id)
     if task is not None:
         return task
     try:
@@ -1719,7 +1719,7 @@ async def _load_task(
         return None
     logger.info(f"Rehydrated task {task_id} from registry data.")
     try:
-        task_store.save_task(task)
+        await task_store.save_task_aio(task)
     except Exception as e:
         logger.warning(f"Failed to write rehydrated task {task_id} back: {e}")
     return task

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -136,7 +136,20 @@ class BuildTaskStore:
         )
 
     def _deserialize(self, task_id: UUID | str, data: bytes) -> BaseTask | None:
-        task = pickle.loads(data)
+        # None (never raise) on a bad entry: the store is a fallback, and the
+        # caller (`_reactive._load_task`) rehydrates from registry data on a
+        # miss — a stale pickle (e.g. from before a redeploy) or a corrupt one
+        # must route there too, not abort the tick.
+        try:
+            task = pickle.loads(data)
+        except Exception:
+            logger.warning(
+                f"Task store entry for {task_id} of build {self.build_id} "
+                f"could not be unpickled (stale after a redeploy, or corrupt); "
+                f"treating it as missing.",
+                exc_info=True,
+            )
+            return None
         if not isinstance(task, BaseTask):
             logger.error(
                 f"Task store entry for {task_id} of build {self.build_id} "

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -81,9 +81,24 @@ class BuildTaskStore:
         with target.open("wb") as handle:
             handle.write(pickle.dumps(task))
 
+    async def save_task_aio(self, task: BaseTask) -> None:
+        # Async variant of save_task; same write-once semantics. Callers on
+        # an event loop must use this one: the sync path does blocking
+        # remote I/O (e.g. Modal's rate-limited volume API) directly on the
+        # loop, stalling every other coroutine for a network round-trip.
+        target = self._target(f"tasks/{task.id}.pkl")
+        if await target.exists_aio():
+            return
+        async with target.open_aio("wb") as handle:
+            await handle.write(pickle.dumps(task))
+
     def save_tasks(self, tasks: typing.Iterable[BaseTask]) -> None:
         for task in tasks:
             self.save_task(task)
+
+    async def save_tasks_aio(self, tasks: typing.Iterable[BaseTask]) -> None:
+        for task in tasks:
+            await self.save_task_aio(task)
 
     def load_task(self, task_id: UUID | str) -> BaseTask | None:
         """Load a task by id; None if not persisted.
@@ -97,13 +112,31 @@ class BuildTaskStore:
         """
         target = self._target(f"tasks/{task_id}.pkl")
         if not target.exists():
-            logger.debug(
-                f"Task {task_id} of build {self.build_id} is not in the "
-                f"build task store (expected when pickles are elided)."
-            )
+            self._log_miss(task_id)
             return None
         with target.open("rb") as handle:
-            task = pickle.loads(handle.read())
+            data = handle.read()
+        return self._deserialize(task_id, data)
+
+    async def load_task_aio(self, task_id: UUID | str) -> BaseTask | None:
+        # Async variant of load_task; same miss semantics (see its docstring
+        # and save_task_aio for why loop-based callers need this).
+        target = self._target(f"tasks/{task_id}.pkl")
+        if not await target.exists_aio():
+            self._log_miss(task_id)
+            return None
+        async with target.open_aio("rb") as handle:
+            data = await handle.read()
+        return self._deserialize(task_id, data)
+
+    def _log_miss(self, task_id: UUID | str) -> None:
+        logger.debug(
+            f"Task {task_id} of build {self.build_id} is not in the "
+            f"build task store (expected when pickles are elided)."
+        )
+
+    def _deserialize(self, task_id: UUID | str, data: bytes) -> BaseTask | None:
+        task = pickle.loads(data)
         if not isinstance(task, BaseTask):
             logger.error(
                 f"Task store entry for {task_id} of build {self.build_id} "

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -825,6 +825,12 @@ class InMemoryTaskStore(BuildTaskStore):
     def load_task(self, task_id):
         return self._tasks.get(str(task_id))
 
+    async def save_task_aio(self, task: BaseTask) -> None:
+        self.save_task(task)
+
+    async def load_task_aio(self, task_id):
+        return self.load_task(task_id)
+
 
 # =============================================================================
 # Helpers

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -78,6 +78,21 @@ async def test_load_task_aio_missing_returns_none(
     assert await store.load_task_aio(uuid4()) is None
 
 
+async def test_corrupt_pickle_reads_as_a_miss(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    # A stale (pre-redeploy) or corrupt entry must load as None — the same
+    # as a miss — so `_reactive._load_task` falls back to registry
+    # rehydration instead of the tick aborting on the raise.
+    store = BuildTaskStore(uuid4())
+    task = SyncOnlyTask(name="corrupt")
+    target = store._target(f"tasks/{task.id}.pkl")
+    with target.open("wb") as handle:
+        handle.write(b"not a pickle")
+    assert store.load_task(task.id) is None
+    assert await store.load_task_aio(task.id) is None
+
+
 def test_load_missing_task_returns_none(
     default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
 ):

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -43,6 +43,41 @@ def test_save_tasks_skips_already_persisted(
     assert store.load_task(b.id) is not None
 
 
+async def test_save_task_aio_is_idempotent(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    store = BuildTaskStore(uuid4())
+    task = SyncOnlyTask(name="ws")
+    await store.save_task_aio(task)
+    await store.save_task_aio(task)
+    loaded = await store.load_task_aio(task.id)
+    assert loaded is not None
+    assert loaded.id == task.id
+
+
+async def test_sync_and_aio_paths_share_the_store(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    # The aio variants exist so loop-based callers (the reactive tick) avoid
+    # blocking I/O on the event loop — they must read/write the very same
+    # entries as the sync path used by the trigger and workers.
+    store = BuildTaskStore(uuid4())
+    a, b = SyncOnlyTask(name="a"), SyncOnlyTask(name="b")
+    store.save_task(a)
+    await store.save_tasks_aio([a, b])  # write-once: overlap must not fail
+    loaded_a = await store.load_task_aio(a.id)
+    assert loaded_a is not None and loaded_a.id == a.id
+    loaded_b = store.load_task(b.id)
+    assert loaded_b is not None and loaded_b.id == b.id
+
+
+async def test_load_task_aio_missing_returns_none(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    store = BuildTaskStore(uuid4())
+    assert await store.load_task_aio(uuid4()) is None
+
+
 def test_load_missing_task_returns_none(
     default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
 ):

--- a/lib/stardag/tests/test_integration/test_modal/test_live_reactive_e2e.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_live_reactive_e2e.py
@@ -195,7 +195,7 @@ def test_reactive_build_completes_without_resident_orchestrator():
         # discover + register + persist task objects, and only THEN set
         # the reactive marker/config in the registry.
         discovery = await discover_and_register_aio(registry, build_id, task)
-        store.save_tasks(discovery.incomplete.values())
+        await store.save_tasks_aio(discovery.incomplete.values())
         await registry.build_set_reactive_meta_aio(
             build_id, app_name=TEST_APP_NAME, tick_kwargs={}
         )


### PR DESCRIPTION
## Problem

The `modal_live` CI tier emits Modal's `AsyncUsageWarning` on
`test_live_reactive_e2e.py::test_reactive_build_completes_without_resident_orchestrator`:
blocking volume-API calls (`volume.iterdir`, `read_file_into_fileobj`,
`batch_upload`) made from a running event loop, at the **sync** methods of
`ModalVolumeRemoteFileSystem` — which already have proper `.aio` twins.

They were reached through `BuildTaskStore`, which was sync-only
(`target.exists()` / `target.open()`) and is called from async code:

- `stardag.build._reactive._load_task` (async) called `load_task(...)` per
  tick, and `save_task(...)` on the rehydration write-back.
- The live e2e test's async trigger called `save_tasks(...)`.

Beyond the warning noise, each such call stalls every other coroutine in a
scheduler tick (spawn probes, registry calls) for a network round-trip.

## Fix

- `BuildTaskStore` gains `save_task_aio` / `save_tasks_aio` /
  `load_task_aio`, built on the targets' existing `exists_aio()` /
  `open_aio()`; the miss/write-once semantics and logging are shared with
  the sync path.
- `_reactive._load_task` and the e2e test trigger use the aio variants.
- The sync methods stay for the genuinely sync call sites
  (`run_reactive_bootstrap` → `_persist_discovered_tasks`, the worker
  runner's dynamic-dep writes).
- The engine tests' `InMemoryTaskStore` fake gets matching aio overrides;
  new unit tests cover the aio methods and sync/aio interop on one store.

## Verification

- `pytest -m "not modal_live" tests`: 1414 passed, zero
  `AsyncUsageWarning`.
- The live e2e test run with `-W error::modal.exception.AsyncUsageWarning`
  passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)