### PR TITLE
Server release 0.3.0: version bump and changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   (`DEFAULT_SERVER_VERSION = "0.3.0"`, from the `server-v0.3.0` release) —
   the server version this SDK release is tested against, and the one that
   carries the two endpoints this release's reactive changes call
-  (`GET /builds/{id}/notify` and the scheduler-lease routes). The image tag
+  (`GET /builds/{build_id}/notify` and the scheduler-lease routes). The
+  image tag
   and `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git
   tag only.
 
@@ -158,7 +159,7 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   `GET /builds/{build_id}/notify` (the linger poll's one-row read) and the
   scheduler lease on the build row —
   `POST`/`PUT`/`DELETE /builds/{build_id}/scheduler-lease` plus the
-  `builds.scheduler_lease_until` / `scheduler_lease_owner` migration
+  `builds.scheduler_lease_until` / `builds.scheduler_lease_owner` migration
   (`b41c7d9e2f08`, no backfill). Minor rather than patch for the same
   reason as `0.2.0`: the HTTP surface grew and there is a schema migration.
   Self-hosters upgrade with `stardag self-host upgrade`; redeploy Modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 - Default prebuilt server image bumped to `0.3.0`
   (`DEFAULT_SERVER_VERSION = "0.3.0"`, from the `server-v0.3.0` release) —
   the server version this SDK release is tested against, and the one that
-  carries the two endpoints this release's reactive changes call
-  (`GET /builds/{build_id}/notify` and the scheduler-lease routes). The
+  carries the new server surface this release's reactive changes call:
+  `GET /builds/{build_id}/notify` and the scheduler-lease routes. The
   image tag
   and `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git
   tag only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,13 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   longest live input, a couple of stale `RUNNING` builds would be enough to
   keep the tick function warm, however few they are.
 
-- Default prebuilt server image bumped to `0.2.0`
-  (`DEFAULT_SERVER_VERSION = "0.2.0"`, from the `server-v0.2.0` release) —
-  the server version this SDK release is tested against. The image tag and
-  `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git tag
-  only.
+- Default prebuilt server image bumped to `0.3.0`
+  (`DEFAULT_SERVER_VERSION = "0.3.0"`, from the `server-v0.3.0` release) —
+  the server version this SDK release is tested against, and the one that
+  carries the two endpoints this release's reactive changes call
+  (`GET /builds/{id}/notify` and the scheduler-lease routes). The image tag
+  and `--server-version` take the bare `X.Y.Z`; `server-v` prefixes the git
+  tag only.
 
 - **The linger poll no longer reads the frontier.**
   `RegistryABC.build_get_notify[_aio]` reads the wake-up flag, and the tick's
@@ -151,6 +153,18 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   for its remaining use (executions without probeable liveness).
 
 ### Deployment
+
+- **Server image `0.3.0`**, carrying the two Registry API changes above:
+  `GET /builds/{build_id}/notify` (the linger poll's one-row read) and the
+  scheduler lease on the build row —
+  `POST`/`PUT`/`DELETE /builds/{build_id}/scheduler-lease` plus the
+  `builds.scheduler_lease_until` / `scheduler_lease_owner` migration
+  (`b41c7d9e2f08`, no backfill). Minor rather than patch for the same
+  reason as `0.2.0`: the HTTP surface grew and there is a schema migration.
+  Self-hosters upgrade with `stardag self-host upgrade`; redeploy Modal
+  apps promptly after — until each app is redeployed, its old ticks take a
+  legacy lock this server no longer reads, so every completion reports no
+  live scheduler and spawns a tick that immediately no-ops.
 
 - **Server image `0.2.0`**, the first server release since `0.1.2`
   (2026-08-12). It carries the Registry API and UI changes recorded under

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -62,7 +62,7 @@ DEFAULT_SERVER_MODAL_ENV = "stardag-host"
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK
 # release time; override per deployment with --server-version.
-DEFAULT_SERVER_VERSION = "0.2.0"
+DEFAULT_SERVER_VERSION = "0.3.0"
 
 # Minimum client interpreter for from-source image builds (stardag-api's
 # requires-python; the image gets the client's version via add_python).


### PR DESCRIPTION
Cuts `server-v0.3.0`, the release carrying the two Registry API changes
merged since `server-v0.2.0`:

- **`GET /builds/{build_id}/notify`** — the linger poll's one-row read (#289)
- **The scheduler lease on the build row** — `POST`/`PUT`/`DELETE
  /builds/{build_id}/scheduler-lease` plus the
  `builds.scheduler_lease_until` / `scheduler_lease_owner` migration
  (`b41c7d9e2f08`, no backfill) (#291)

No UI changes. **Minor rather than patch** for the same reason as `0.2.0`:
the HTTP surface grew and there is a schema migration.

`DEFAULT_SERVER_VERSION` moves to `0.3.0` so the next SDK release deploys a
server that has the endpoints its own reactive changes call — leaving the
pin at `0.2.0` would have a fresh `stardag self-host up` install a server
the new tick silently degrades against, which is the exact lag the release
cadence (DEV_README.md, "When to cut one") exists to prevent.

After merge: tag `server-v0.3.0` on the squash commit →
`publish-server-image.yml` publishes `ghcr.io/stardag-dev/stardag-server:0.3.0`
and the GitHub Release with the UI dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiH7NXTHNZGoG4wF6RsY3x