### PR TITLE
Stop the blocked frontend majors squatting the UI PR budget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,35 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Held back because the UI needs code changes first, not because the
+    # version is bad. Each of these blocks on work tracked in
+    # `.claude/tasks/frontend-dep-migrations.md`, and **deleting the ignore is
+    # step one of doing that work** — they are placeholders, not decisions.
+    #
+    # Only things blocked on *us* are listed. Anything blocked upstream is
+    # deliberately left to open a PR: `typescript` 7 is unusable today because
+    # typescript-eslint peers at `<6.1.0`, and when that changes the PR going
+    # green is how we find out. An ignore would hide it.
+    ignore:
+      # 7.1 adds set-state-in-effect and preserve-manual-memoization to its
+      # recommended set, which flags 33 pre-existing errors. Minor by version
+      # number, breaking in effect — which is why the minor/patch group below
+      # cannot protect itself from it. Coupled to eslint 10: 7.0.x peers at
+      # eslint ^9, so these three move together or not at all.
+      - dependency-name: "eslint-plugin-react-hooks"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      # v4 is an API rewrite: PanelGroup -> Group, PanelResizeHandle ->
+      # Separator, refs move to usePanelRef() hooks. BuildView and
+      # TaskExplorer both need porting, with the collapse behaviour checked by
+      # hand.
+      - dependency-name: "react-resizable-panels"
+        update-types: ["version-update:semver-major"]
     groups:
       stardag-ui-minor-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,9 +58,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     # Held back because the UI needs code changes first, not because the
-    # version is bad. Each of these blocks on work tracked in
-    # `.claude/tasks/frontend-dep-migrations.md`, and **deleting the ignore is
-    # step one of doing that work** — they are placeholders, not decisions.
+    # version is bad. **Deleting the ignore is step one of doing that work** —
+    # these are placeholders, not decisions, and each says below what has to
+    # be true before it goes.
     #
     # Only things blocked on *us* are listed. Anything blocked upstream is
     # deliberately left to open a PR: `typescript` 7 is unusable today because


### PR DESCRIPTION
Closes STA-31.

## Problem

The minor/patch split from #299 has a hole: **a behaviourally breaking
change can ship as a semver-minor**, and then it lands in the "safe"
group anyway.

`eslint-plugin-react-hooks` 7.0.1 → 7.1.1 is exactly that. It adds
`set-state-in-effect` and `preserve-manual-memoization` to its
`flat.recommended` set, which flag **33 pre-existing errors** in the UI.
So #306 is red and nine genuinely routine updates — `@xyflow/react`,
`@testing-library/*`, `@types/node`, `typescript-eslint` 8.67→8.68 — are
stuck behind it.

There is a second, more concrete cost that settled the approach.
`app/stardag-ui` had **5 open PRs against a limit of 5**:

```
#306  stardag-ui-minor-patch     (blocked by react-hooks)
#308  react-resizable-panels 4   (needs an API port)
#309  typescript 7               (blocked upstream)
#310  @eslint/js 10              (needs the react-hooks migration)
#311  eslint 10                  (needs the react-hooks migration)
```

Dependabot had stopped proposing anything new for the UI at all. Work
blocked on migrations was consuming the entire budget.

## What

`ignore` entries for the four that are blocked **on us**, each naming its
reason inline.

They are placeholders for tracked work, not decisions, so the comment
says so explicitly — *deleting the ignore is step one of doing the
migration*. Without that an ignore becomes permanent by inertia, which
would be worse than the red PR it replaced.

## The line I drew

Only things blocked on **us** are ignored. `typescript` 7 is deliberately
left to keep opening a PR (#307, #309).

It is unusable today because `typescript-eslint` peers at
`typescript: >=4.8.4 <6.1.0` and `ts-jest` at `<7` — but that is
upstream's to fix, and **the PR turning green is how we find out it has
been**. An ignore would hide the one signal actually worth having. A
permanently-red PR that will one day go green is doing a job; a
permanently-red PR waiting on our own backlog is not.

## Follow-up

#306 needs recreating once this lands — it should come back with the nine
routine updates and no react-hooks. #308, #310 and #311 can then be
closed; they will not be re-proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)