### PR TITLE
Skip the Modal jobs on runs that get no secrets, not just on forks

### DIFF
--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -154,8 +154,15 @@ jobs:
           [ "$HEAD_REPO" = "$REPO" ] || both false \
             "PR is from a fork ($HEAD_REPO); GitHub withholds the Modal credentials."
 
+          #
+          # To run the tiers on a dependabot PR anyway -- worth it when the
+          # bump touches something the live tiers exercise -- add the
+          # `modal-live` label. `labeled` is one of this workflow's triggers,
+          # and the labelling run is attributed to whoever clicked, so it gets
+          # the credentials this one does not. The label check below then
+          # forces both tiers.
           [ "$ACTOR" = "dependabot[bot]" ] && both false \
-            "triggered by dependabot; GitHub withholds the Modal credentials."
+            "triggered by dependabot; GitHub withholds the Modal credentials. Add the 'modal-live' label to run them."
 
           [ "$LABELLED" = "true" ] && both true "Labelled modal-live."
 

--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -118,6 +118,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          ACTOR: ${{ github.actor }}
           PR: ${{ github.event.pull_request.number }}
           LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'modal-live') }}
         run: |
@@ -144,10 +145,17 @@ jobs:
 
           [ "$EVENT" = "pull_request" ] || both true "$EVENT -- running both tiers."
 
-          # Fork PRs receive no secrets, so this could only fail in require
-          # mode. Skipping is the honest outcome, not a green tick.
+          # The rule is "this run gets no secrets", so the tiers could only
+          # fail in require mode. Skipping is the honest outcome, not a green
+          # tick. Two things trigger it, and they are unrelated causes:
+          # a fork PR, and any run dependabot triggered (its PRs live in this
+          # repo, so the fork check below does not catch them -- GitHub keeps
+          # Dependabot secrets in a separate store).
           [ "$HEAD_REPO" = "$REPO" ] || both false \
             "PR is from a fork ($HEAD_REPO); GitHub withholds the Modal credentials."
+
+          [ "$ACTOR" = "dependabot[bot]" ] && both false \
+            "triggered by dependabot; GitHub withholds the Modal credentials."
 
           [ "$LABELLED" = "true" ] && both true "Labelled modal-live."
 
@@ -401,10 +409,15 @@ jobs:
     name: Delete the closed PR's Modal environment
     runs-on: ubuntu-latest
     permissions: {}
+    # `github.actor` and not the PR author: secrets are withheld from runs
+    # dependabot *triggered*, so a dependabot PR closed by a human does get
+    # them, and should be cleaned up normally. Only dependabot closing its own
+    # superseded PR needs skipping.
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     environment: modal-live-ci
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -453,10 +466,14 @@ jobs:
     # costs a listing and a lookup per `ci-*` environment, and it does not
     # widen what it is willing to delete by one name.
     #
-    # Fork PRs are excluded because they receive no secrets; the job would
-    # go red for want of a Modal token rather than for anything it found.
+    # Runs that receive no secrets are excluded: the job would go red for want
+    # of a Modal token rather than for anything it found. Two unrelated causes
+    # produce that, and naming only one of them is how this regressed --
+    # dependabot's PRs are not forks, so the fork check let them through and
+    # every dependabot PR carried a red sweep.
     if: >-
       always() &&
+      github.actor != 'dependabot[bot]' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     environment: modal-live-ci


### PR DESCRIPTION
Closes STA-32.

## Problem

Every dependabot PR carried a red check:

```
Sweep stale Modal environments — Token missing. Could not authenticate client.
```

GitHub withholds repository and environment secrets from runs dependabot
triggers (Dependabot secrets live in a separate store), so the sweeper
failed for want of a Modal token rather than for anything it found.

Not a merge blocker — it is not a required context. The cost is signal:
**every** dependabot PR was red, which trains the eye to skip past a red
X on exactly the PRs where a real failure matters. #307's genuine
`Test Infra (aws-cdk)` failure sat next to this one and looked identical
at a glance.

## The workflow already reasoned about this

It even documented it:

```
# Fork PRs are excluded because they receive no secrets; the job would
# go red for want of a Modal token rather than for anything it found.
```

Right rule, one instance. Dependabot's PRs are **not** forks — the branch
lives in this repo, so `head.repo.full_name == github.repository` is true
and the guard let them straight through. The comments now name the rule
itself rather than one of its causes, so the next secret-less context
does not reopen this.

## Three places, not one

Checking the siblings turned up the same gap in:

- **`decide`** — would have set both live tiers to run on a dependabot PR
  touching their paths, then failed in *require* mode.
- **`cleanup-closed-pr`**
- **`sweep-stale-environments`** — the one actually going red today.

## Why `github.actor` and not the PR author

This is the part worth checking, because the obvious choice is wrong.

Secrets are withheld from runs dependabot **triggered**, not from PRs
dependabot **authored**. A dependabot PR closed by a human runs with full
secrets and *should* be cleaned up normally.

Verified rather than assumed: the `cleanup-closed-pr` runs for #300 and
#301 — both dependabot PRs, both closed by hand — **succeeded**. Keying
on `pull_request.user.login` would have skipped those and leaked any
environment they held. `github.actor` keeps them running and skips only
the case that genuinely has no credentials, including dependabot closing
its own superseded PR.

## Verification

- YAML parses; both `if:` guards confirmed present on the two jobs.
- `decide`'s shell branch simulated for both actors: `dependabot[bot]` →
  both tiers false, anything else → proceeds to path matching.
- Confirmed the `[ … ] && both …` form does not trip `set -euo pipefail`
  on its false branch — same shape as the existing `LABELLED` line.

Skipping is correct rather than a workaround: a run with no credentials
creates no Modal environment, so there is nothing for the sweeper to
find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)