### PR TITLE
Work against modal's renamed FileEntryType and FunctionInfo

### DIFF
--- a/lib/stardag/src/stardag/integration/modal/_target.py
+++ b/lib/stardag/src/stardag/integration/modal/_target.py
@@ -26,7 +26,9 @@ try:
     from modal.types import (  # pyright: ignore[reportMissingImports]
         FileEntryType,
     )
-except ImportError:  # no `modal.types` yet — still inside `modal>=1.0.0`
+except ModuleNotFoundError:  # no `modal.types` yet — inside `modal>=1.0.0`
+    # Narrow on purpose: a broken `modal.types` should surface, not fall
+    # through to a stale import path.
     from modal.volume import (
         FileEntryType,  # pyright: ignore[reportAttributeAccessIssue]
     )

--- a/lib/stardag/src/stardag/integration/modal/_target.py
+++ b/lib/stardag/src/stardag/integration/modal/_target.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import aiofiles
 import modal
 from modal.exception import NotFoundError, ResourceExhaustedError
-from modal.volume import FileEntryType
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 from tenacity import (
@@ -18,6 +17,19 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential_jitter,
 )
+
+try:
+    # Newer modal defines this in the public `modal.types`. `modal.volume`
+    # still re-exports it at runtime, but its .pyi no longer does, so
+    # importing it from there resolves fine and then type-checks as a
+    # missing symbol.
+    from modal.types import (  # pyright: ignore[reportMissingImports]
+        FileEntryType,
+    )
+except ImportError:  # no `modal.types` yet — still inside `modal>=1.0.0`
+    from modal.volume import (
+        FileEntryType,  # pyright: ignore[reportAttributeAccessIssue]
+    )
 
 from stardag.integration.modal._config import modal_config_provider
 from stardag.target import (

--- a/lib/stardag/tests/test_selfhost/test_image_source.py
+++ b/lib/stardag/tests/test_selfhost/test_image_source.py
@@ -109,7 +109,18 @@ def test_prebuilt_functions_are_by_reference_file_entrypoints():
     imports it in-container by its stem (``_modal_entry``) - no cloudpickle,
     so the deploy is independent of the client interpreter version.
     """
-    from modal._utils.function_utils import FunctionInfo
+    try:
+        # Newer modal renamed FunctionInfo -> FunctionSourceInfo. Same
+        # constructor and the same three properties this asserts on; the
+        # rename landed in a patch release, which is why both names are
+        # handled rather than pinned to one.
+        from modal._utils.function_utils import (
+            FunctionSourceInfo as FunctionInfo,  # pyright: ignore[reportAttributeAccessIssue]
+        )
+    except ImportError:  # older modal
+        from modal._utils.function_utils import (
+            FunctionInfo,  # pyright: ignore[reportAttributeAccessIssue]
+        )
 
     from stardag.selfhost._modal_app import _load_prebuilt_entry_module
 

--- a/lib/stardag/tests/test_selfhost/test_image_source.py
+++ b/lib/stardag/tests/test_selfhost/test_image_source.py
@@ -117,6 +117,9 @@ def test_prebuilt_functions_are_by_reference_file_entrypoints():
         from modal._utils.function_utils import (
             FunctionSourceInfo as FunctionInfo,  # pyright: ignore[reportAttributeAccessIssue]
         )
+    # ImportError and not ModuleNotFoundError, unlike the `modal.types`
+    # fallback in _target.py: here the *module* exists on both versions and
+    # only the symbol moved, which does not raise ModuleNotFoundError.
     except ImportError:  # older modal
         from modal._utils.function_utils import (
             FunctionInfo,  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
Closes STA-33. Unblocks #316.

## What broke

modal **1.5.5** moved two symbols — in a *patch* release:

| before | after |
| --- | --- |
| `modal.volume.FileEntryType` | `modal.types.FileEntryType` |
| `modal._utils.function_utils.FunctionInfo` | `…FunctionSourceInfo` |

**`FileEntryType`** still re-exports from `modal.volume` at runtime, so
production code kept working — but `modal/volume.pyi` no longer lists it,
so pyright reports an unknown import symbol.

**`FunctionInfo`** is genuinely gone, and
`tests/test_selfhost/test_image_source.py` imported it, so `Test Python`
failed outright on all four versions.

That is what has been holding #316 — the grouped Python PR — and with it
ten unrelated updates across six directories.

## Not a release problem

Worth stating, since `pyproject.toml` declares `modal>=1.0.0` and the
lockfile pin protects only CI: **users were never affected.** Installing
`modal==1.5.5` against `lib/stardag` and importing
`stardag.integration.modal` works, and `FileEntryType` resolves at
runtime. This was test and type-checking maintenance.

## The fix

A fallback rather than a pin, because both spellings sit inside the
declared `modal>=1.0.0` range and a pin would break one end of it.
`FunctionSourceInfo` is a pure rename for what the test needs: same
constructor, and `is_serialized()`, `module_name` and `function_name`
behave identically (checked against a real callable).

**Each branch carries a pyright ignore, which looks redundant and is
not.** Whichever modal is installed, the *other* branch cannot resolve —
so pyright flags one or the other depending on version. That is inherent
to a cross-version shim, and it is why the first attempt (ignoring only
the fallback) passed locally against 1.5.5 and then failed the
`pyright-stardag` hook, which syncs 1.5.0 from the lockfile.

## Verification — both directions

| | modal 1.5.0 (current lock) | modal 1.5.5 (what #316 brings) |
| --- | --- | --- |
| pyright | 0 errors | 0 errors |
| test suite | **1444 passed** | **1444 passed** |

Also confirmed the imports resolve to the right place per version:
`modal.volume.FileEntryType` on 1.5.0, `modal.types.FileEntryType` on
1.5.5.

## Left deliberately undone

The test reaches into `modal._utils`, which is precisely what let a patch
release break it. I did not remove that dependency here: the assertion is
about *Modal's own* classification of the entry module as a by-reference
file entrypoint, and there is no public API that answers it —
re-implementing the check against `__module__`/`__qualname__` would
duplicate Modal's logic and could drift from it silently, which is worse
than the fragility it replaces.

The cleaner long-term fix is raising the `modal>=1.0.0` floor, which
would let both fallbacks go entirely. That is a user-facing constraint
change and worth weighing on its own rather than smuggling in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)