### PR TITLE
Make require_pickle_free bind the tick, not just the trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **`require_pickle_free=True` now binds the scheduler tick, not just the
+  trigger.** The flag was a trigger-time gate: the bootstrap refused to start
+  a build whose tasks would need pickles, and nothing carried the intent any
+  further. But a tick is a writer of the same store — it wrote back every task
+  it rehydrated from registry data — so on a writable target root a build that
+  declared it writes no pickles quietly left them there anyway, one per task,
+  the first time each was rehydrated. Where the class could not be pickled the
+  write merely failed, warning once per rehydration per tick. `BuildTaskStore`
+  now takes `pickle_free`, which makes every write a no-op, and the deployed
+  tick builds its store from the app's flag. Nothing is lost by skipping: the
+  write-back is a cache over an object the caller already holds, and on such a
+  build every task is rehydratable by construction. Unchanged: the trigger-time
+  gate, and the documented carve-out for an uncovered _dynamic_ dependency
+  registered from inside a worker, which still gets its pickle rather than
+  failing the bookkeeping of a task that has already run.
+
 - **`--server-version latest` is resolved at deploy time, not deployed as a
   tag.** `stardag self-host up/upgrade --server-version latest` now asks the
   GitHub Releases API for the newest `server-vX.Y.Z`, prints what it resolved

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -547,10 +547,18 @@ discovered task whose class is covered _and_ whose payload round-trips to
 the same task id is persisted **without a pickle**. A build whose classes
 are all covered writes nothing to the target root at all. Set
 `require_pickle_free=True` to turn the fallback into a hard error that
-names every task that would have needed a pickle and why — enforced in
+names every task that would have needed a pickle and why — gated in
 the `bootstrap` container, where the task store is written, and loud:
 it fails the build in the registry _and_ propagates on
-`result.function_call.get()`.
+`result.function_call.get()`. Ticks of such an app also get a task store
+that refuses every write, so the flag means "no pickles" for the life of
+the build and not merely at its start: a tick that rebuilds a task from
+registry data would otherwise cache it back as a pickle, on a target root
+you asked it never to write to. The one remaining exception is a
+**dynamic dependency whose class is not covered** — registered from
+inside a worker whose task has already run, where failing the bookkeeping
+to enforce a storage preference would be the worse outcome, so it still
+gets its pickle.
 
 **Skipping pickles requires the explicit declaration** — the inferred
 default never elides on its own. Inference happens for every app,

--- a/lib/stardag/src/stardag/build/_reactive/_frontier_actions.py
+++ b/lib/stardag/src/stardag/build/_reactive/_frontier_actions.py
@@ -177,10 +177,21 @@ async def _load_task(
     The pickle-free fallback reconstructs the task from the registry's
     stored ``task_data`` (see ``stardag.task_from_registry_data``) — which
     also survives cases the pickle store can't (e.g. an app redeploy with
-    compatible task definitions invalidating stored pickles). Successful
-    rehydrations are written back to the store (best-effort: the task
-    object is already in hand, so a transient store error must not abort
-    the caller).
+    compatible task definitions invalidating stored pickles).
+
+    Successful rehydrations are written back to the store, so a build that
+    fell back once does not keep paying for it. Two qualifications, in
+    this order:
+
+    * **Not on a pickle-free store.** A build whose app declared
+      ``require_pickle_free`` gets a store that refuses every write, so
+      this call is a no-op there — the cache would otherwise leave pickles
+      on a target root the build promised never to write to, silently and
+      on a build where rehydration is the *designed* path rather than a
+      fallback. The guard lives in ``BuildTaskStore.save_task_aio``, which
+      is why no argument is threaded down here.
+    * **Best-effort when it does write.** The task object is already in
+      hand, so a store error must not abort the caller.
 
     With ``quiet=True`` a rehydration failure logs a single warning without
     the stack trace — for callers where a missing object is tolerated (a
@@ -213,7 +224,15 @@ async def _load_task(
         else:
             logger.exception(f"{message}.{note}")
         return None
-    logger.info(f"Rehydrated task {task_id} from registry data.")
+    # DEBUG on a pickle-free build, INFO otherwise: there, a store miss is
+    # the expected path for every task on every tick, and reporting it at
+    # INFO trains readers to skim the scheduler's log lines on the very
+    # configuration the feature recommends. Elsewhere a miss means a pickle
+    # was expected and was not there, which is worth a line.
+    if task_store.pickle_free:
+        logger.debug(f"Rehydrated task {task_id} from registry data.")
+    else:
+        logger.info(f"Rehydrated task {task_id} from registry data.")
     try:
         await task_store.save_task_aio(task)
     except Exception as e:

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -32,6 +32,15 @@ remains are the payloads that genuinely cannot be reconstructed:
 ``AliasTask`` (pickled ``loads_type``, deliberately never auto-unpickled
 from registry data), dynamically generated classes, and anything whose
 serialization does not round-trip to the same task id.
+
+``pickle_free=True`` turns that preference into a guarantee: every write
+becomes a no-op, for a build whose app declared ``require_pickle_free``.
+The flag belongs on the store because the writers are spread across the
+trigger, the workers and the scheduler tick, and only the trigger's is
+close enough to the app to consult the declaration itself — the tick's
+rehydration write-back sits several frames below anything that knows what
+the build asked for, and duly wrote pickles to builds that had forbidden
+them. A store that refuses is the one place all writers pass through.
 """
 
 from __future__ import annotations
@@ -56,9 +65,19 @@ class BuildTaskStore:
         self,
         build_id: UUID,
         target_root_key: str = DEFAULT_TARGET_ROOT_KEY,
+        *,
+        pickle_free: bool = False,
     ) -> None:
         self.build_id = build_id
         self.target_root_key = target_root_key
+        # The build declared ``require_pickle_free`` (see
+        # ``StardagApp``): every write is a no-op. Carried by the store
+        # rather than passed per call because the writers are spread
+        # across the trigger, the workers and the scheduler tick, and the
+        # one that leaked — the tick's rehydration write-back in
+        # ``_reactive._load_task`` — is several frames below anything that
+        # knows what the build declared.
+        self.pickle_free = pickle_free
 
     def _target(self, relpath: str):
         return target_factory_provider.get().get_file_target(
@@ -69,6 +88,32 @@ class BuildTaskStore:
     # --- task pickles ---
 
     def save_task(self, task: BaseTask) -> None:
+        """Persist ``task``, unless this build declared itself pickle-free.
+
+        The guard lives here, not at the call sites, so that "this build
+        writes no task pickles" is a property of the store and cannot be
+        forgotten by a writer — which is exactly how the tick's
+        rehydration write-back came to violate it. Subclasses override
+        :meth:`_write_task`, so they inherit the guard too.
+
+        Skipping is silent by design: on a pickle-free build the caller
+        already holds the task object (rehydration produced it), so the
+        write was only ever a cache and nothing is lost by not doing it.
+        """
+        if self.pickle_free:
+            self._log_skipped_write(task)
+            return
+        self._write_task(task)
+
+    async def save_task_aio(self, task: BaseTask) -> None:
+        # Async variant of save_task; same pickle-free guard and write-once
+        # semantics.
+        if self.pickle_free:
+            self._log_skipped_write(task)
+            return
+        await self._write_task_aio(task)
+
+    def _write_task(self, task: BaseTask) -> None:
         # Write-once: a task id maps to one immutable object, so an existing
         # pickle is already correct — skip it. This keeps the store
         # compatible with immutable/append-only target roots and lets
@@ -81,8 +126,8 @@ class BuildTaskStore:
         with target.open("wb") as handle:
             handle.write(pickle.dumps(task))
 
-    async def save_task_aio(self, task: BaseTask) -> None:
-        # Async variant of save_task; same write-once semantics. Callers on
+    async def _write_task_aio(self, task: BaseTask) -> None:
+        # Async variant of _write_task; same write-once semantics. Callers on
         # an event loop must use this one: the sync path does blocking
         # remote I/O (e.g. Modal's rate-limited volume API) directly on the
         # loop, stalling every other coroutine for a network round-trip.
@@ -91,6 +136,12 @@ class BuildTaskStore:
             return
         async with target.open_aio("wb") as handle:
             await handle.write(pickle.dumps(task))
+
+    def _log_skipped_write(self, task: BaseTask) -> None:
+        logger.debug(
+            f"Not persisting task {task.id} of build {self.build_id}: the "
+            f"build declared require_pickle_free."
+        )
 
     def save_tasks(self, tasks: typing.Iterable[BaseTask]) -> None:
         for task in tasks:

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -515,18 +515,28 @@ class StardagApp:
                 and why. Off by default (the fallback is what keeps the
                 feature additive).
 
-                Enforced by the reactive bootstrap, where the task
+                The *gate* is the reactive bootstrap, where the task
                 store is written — normally in the ``bootstrap``
                 container. It fails loudly: the ``TaskModulesError``
                 records a terminal BUILD_FAILED and is re-raised on the
                 bootstrap's Modal call, so it surfaces both in the
                 registry and on
-                ``BuildTriggerResult.function_call.get()``. Dynamic
-                dependencies registered from inside a worker apply the
-                same elision but never raise: their task has already run,
-                and failing its bookkeeping to enforce a storage
-                preference would be a strictly worse outcome than one
-                extra pickle.
+                ``BuildTriggerResult.function_call.get()``.
+
+                The *guarantee* is separate, because the bootstrap is not
+                the only writer: a scheduler tick writes back the tasks it
+                rehydrates. Ticks of an app with this flag therefore get a
+                store that refuses every write (see
+                ``BuildTaskStore(pickle_free=...)``), which costs nothing —
+                the write-back is a cache, and on such a build every task
+                is rehydratable by construction.
+
+                One documented exception, unchanged: dynamic dependencies
+                registered from inside a worker apply the same elision but
+                never raise, and an uncovered one still gets its pickle.
+                Their task has already run, and failing its bookkeeping to
+                enforce a storage preference would be a strictly worse
+                outcome than one extra pickle.
             modal_workspace: Explicit Modal workspace name recorded in the
                 executor metadata of triggered builds and started tasks
                 (used by the UI for Modal dashboard deep links). Default:
@@ -1005,6 +1015,10 @@ class StardagApp:
             ),
             task_modules=tuple(task_modules),
             task_module_patterns=task_module_patterns,
+            # The tick writes to the build task store too (rehydrating a
+            # task writes it back), so the flag has to reach it or the
+            # "writes no pickles" promise holds only until the first tick.
+            require_pickle_free=self.require_pickle_free,
         )
 
         def _modal_tick(

--- a/lib/stardag/src/stardag/integration/modal/_bootstrap.py
+++ b/lib/stardag/src/stardag/integration/modal/_bootstrap.py
@@ -165,6 +165,14 @@ def _persist_discovered_tasks(
     including apps written before the feature existed, and an SDK upgrade
     must never start dropping pickles on its own.
     """
+    # Deliberately NOT a ``pickle_free=require_pickle_free`` store, unlike
+    # the tick's (see ``_TickDeployment.require_pickle_free``). Here the
+    # gate below is the enforcement, and it is exact: it names the offending
+    # tasks and fails the build. A store that silently dropped the same
+    # writes would, if the gate ever stopped firing first, leave a build
+    # that starts fine and stalls later at "could not rehydrate" — strictly
+    # the worse failure. The tick has no such gate and nothing to lose: its
+    # write-back is a cache over an object it already holds.
     store = BuildTaskStore(build_id)
     if not task_module_patterns or not elide_pickles:
         store.save_tasks(tasks)

--- a/lib/stardag/src/stardag/integration/modal/_tick.py
+++ b/lib/stardag/src/stardag/integration/modal/_tick.py
@@ -239,6 +239,15 @@ class _TickDeployment:
         task_module_patterns: The declared patterns behind that list,
             published for the coverage checks that report against patterns
             rather than expansions.
+        require_pickle_free: The app's ``require_pickle_free``, which the
+            tick needs because it is a *writer* of the build task store —
+            rehydrating a task writes it back — and the flag's promise is
+            that the build writes no pickles at all. Deploy-time like the
+            module list beside it, and for the same reason: the flag
+            describes the deployment (an immutable target root, or a
+            redeploy that makes stored pickles a liability), and the
+            trigger's own copy is the caller's local app definition rather
+            than the one the ticks were built from.
     """
 
     app_name: str
@@ -249,6 +258,7 @@ class _TickDeployment:
     tick_timeout_seconds: float | None
     task_modules: tuple[str, ...]
     task_module_patterns: tuple[str, ...]
+    require_pickle_free: bool
 
 
 def _run_tick(
@@ -270,7 +280,7 @@ def _run_tick(
     _setup_logging()
     app_name = deployment.app_name
     build_uuid = UUID(build_id)
-    task_store = BuildTaskStore(build_uuid)
+    task_store = BuildTaskStore(build_uuid, pickle_free=deployment.require_pickle_free)
     registry = registry_provider.get()
     # The reactive marker/owner/config live in the registry (not on
     # the target root): read them with the lighter GET /builds/{id}

--- a/lib/stardag/tests/test_build/reactive_fakes.py
+++ b/lib/stardag/tests/test_build/reactive_fakes.py
@@ -802,20 +802,25 @@ class InMemoryTaskStore(BuildTaskStore):
 
     Pickle-only now: the reactive marker/owner/config live in the registry
     (see ``FakeReactiveRegistry.reactive_meta``), not the store.
+
+    Overrides the ``_write_task`` hooks, not ``save_task`` itself, so the
+    base class's ``pickle_free`` guard applies here exactly as it does in
+    production. A double that wrote where the real store refuses would make
+    the tests for that guard vacuous.
     """
 
-    def __init__(self, build_id: UUID):
-        super().__init__(build_id)
+    def __init__(self, build_id: UUID, *, pickle_free: bool = False):
+        super().__init__(build_id, pickle_free=pickle_free)
         self._tasks: dict[str, BaseTask] = {}
 
-    def save_task(self, task: BaseTask) -> None:
+    def _write_task(self, task: BaseTask) -> None:
         self._tasks[str(task.id)] = task
 
     def load_task(self, task_id):
         return self._tasks.get(str(task_id))
 
-    async def save_task_aio(self, task: BaseTask) -> None:
-        self.save_task(task)
+    async def _write_task_aio(self, task: BaseTask) -> None:
+        self._write_task(task)
 
     async def load_task_aio(self, task_id):
         return self.load_task(task_id)

--- a/lib/stardag/tests/test_build/test_reactive_frontier_actions.py
+++ b/lib/stardag/tests/test_build/test_reactive_frontier_actions.py
@@ -508,6 +508,119 @@ class TestRehydrationFallback:
         assert summary.terminal_status == "failed"
 
 
+class TestRehydrationOnAPickleFreeBuild:
+    """``require_pickle_free`` binds the tick too, not just the trigger.
+
+    The trigger-time gate (``PickleElisionPlan.require_pickle_free_error``)
+    only ever inspected the DAG before the build started. The tick is a
+    *writer* of the same store — a rehydrated task was written straight back
+    — so on a writable target root a build that declared it writes no
+    pickles quietly accumulated them anyway, one per task, the first time
+    each was rehydrated.
+    """
+
+    @staticmethod
+    def _decorator_built_dag():
+        """A DAG whose class is rehydratable but NOT picklable by reference.
+
+        ``@sd.task`` generates a class whose name differs from the module
+        attribute holding it, so ``pickle.dumps`` fails on it — which is what
+        made the write-back audible (a warning every tick) rather than merely
+        wrong. Registry-data rehydration is unaffected: it is a lookup in the
+        polymorphic registry, not a pickle.
+        """
+        import stardag as sd
+
+        @sd.task(name="PickleFreeRehydrateTask")
+        def pickle_free_task(limit: int) -> list[int]:
+            return list(range(limit))
+
+        return pickle_free_task(limit=3)
+
+    @staticmethod
+    def _registry_for(root):
+        registry = FakeReactiveRegistry(
+            root_task_ids=[str(root.id)], auto_complete=True
+        )
+        registry.add_task(str(root.id))
+        registry.metadata_bodies[str(root.id)] = root.model_dump(mode="json")
+        return registry
+
+    async def test_the_rehydrated_task_is_not_written_back(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        root = self._decorator_built_dag()
+        registry = self._registry_for(root)
+        store = InMemoryTaskStore(uuid4(), pickle_free=True)
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=(executor := FakeTickExecutor()),
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        # Rehydration still works and the task is still scheduled — the
+        # write-back was only ever a cache over an object already in hand.
+        assert executor.spawned == [root.id]
+        assert summary.terminal_status == "completed"
+        # ...and the build kept the property it declared.
+        assert store.load_task(root.id) is None
+
+    async def test_no_warning_is_logged(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """The visible half of the bug: a failed write-back warned per tick.
+
+        On a build of unpicklable-by-reference classes the write could not
+        succeed, so the cost was log noise — which matters most exactly where
+        this configuration is used, in CI, where it competed with real signal.
+        """
+        root = self._decorator_built_dag()
+        registry = self._registry_for(root)
+        store = InMemoryTaskStore(uuid4(), pickle_free=True)
+
+        with caplog.at_level(logging.DEBUG):
+            await run_tick_aio(
+                uuid4(),
+                registry=registry,
+                task_executor=FakeTickExecutor(),
+                task_store=store,
+                config=FAST_TICK,
+            )
+
+        loader = "stardag.build._reactive._frontier_actions"
+        records = [r for r in caplog.records if r.name == loader]
+        assert [r for r in records if r.levelno >= logging.WARNING] == []
+        # Rehydration is the designed path here, not an exception to report:
+        # it happens for every task on every tick, so it is DEBUG, not INFO.
+        rehydrated = [r for r in records if "Rehydrated task" in r.getMessage()]
+        assert rehydrated and all(r.levelno == logging.DEBUG for r in rehydrated)
+
+    async def test_an_ordinary_build_still_caches_the_rehydration(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The skip is opt-in. A build that did not declare pickle-freedom
+        still heals its store, which is the whole point of the write-back:
+        there, a miss means a pickle was expected and was not there."""
+        root = self._decorator_built_dag()
+        registry = self._registry_for(root)
+        store = InMemoryTaskStore(uuid4())
+
+        await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=FakeTickExecutor(),
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert store.load_task(root.id) is not None
+
+
 class TestRehydrationDiagnostics:
     """A rehydration failure names the declared task modules that failed to
     import — "class X unresolved" and "the module defining X blew up on

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -124,3 +124,71 @@ def test_load_missing_task_does_not_log_an_error(
     records = [r for r in caplog.records if r.name == logger_name]
     assert [r for r in records if r.levelno >= logging.WARNING] == []
     assert any(r.levelno == logging.DEBUG for r in records)
+
+
+class TestPickleFreeStore:
+    """``require_pickle_free`` reaches the store, so no writer can violate it.
+
+    The flag used to be a trigger-time gate only, which left the scheduler
+    tick — a writer, via the rehydration write-back in ``_load_task`` — free
+    to put pickles on a target root the build had declared it would never
+    write to.
+    """
+
+    def test_save_task_writes_nothing(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        store = BuildTaskStore(uuid4(), pickle_free=True)
+        task = SyncOnlyTask(name="pickle-free")
+        store.save_task(task)
+        assert store.load_task(task.id) is None
+
+    async def test_save_task_aio_writes_nothing(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        # The tick's write-back is the async one; the sync path above is not
+        # evidence about it.
+        store = BuildTaskStore(uuid4(), pickle_free=True)
+        task = SyncOnlyTask(name="pickle-free-aio")
+        await store.save_task_aio(task)
+        assert await store.load_task_aio(task.id) is None
+
+    def test_save_tasks_writes_nothing(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        store = BuildTaskStore(uuid4(), pickle_free=True)
+        a, b = SyncOnlyTask(name="pf-a"), SyncOnlyTask(name="pf-b")
+        store.save_tasks([a, b])
+        assert store.load_task(a.id) is None
+        assert store.load_task(b.id) is None
+
+    def test_the_skip_is_silent(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        # A tick rehydrates every task of such a build on every pass, so
+        # anything above DEBUG here is per-task, per-tick noise — the same
+        # reason a store miss was demoted (see the test above). Nothing is
+        # lost by skipping: the caller already holds the object.
+        store = BuildTaskStore(uuid4(), pickle_free=True)
+        logger_name = "stardag.build._task_store"
+        with caplog.at_level(logging.DEBUG, logger=logger_name):
+            store.save_task(SyncOnlyTask(name="pf-quiet"))
+        records = [r for r in caplog.records if r.name == logger_name]
+        assert [r for r in records if r.levelno > logging.DEBUG] == []
+        assert any(r.levelno == logging.DEBUG for r in records)
+
+    def test_default_still_writes(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        # The flag is opt-in: a build that did not declare it keeps the
+        # store it always had.
+        store = BuildTaskStore(uuid4())
+        task = SyncOnlyTask(name="pf-default")
+        store.save_task(task)
+        assert store.load_task(task.id) is not None

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1808,6 +1808,87 @@ class TestReactivePickleElision:
 
         assert BuildTaskStore(result.build_id).load_task(root.id) is None
 
+    def test_the_flag_reaches_the_deployed_tick(self):
+        """The trigger-time gate is not the whole promise: a tick writes to
+        the store too (it caches the tasks it rehydrates), so the flag has to
+        be baked into the deployment alongside the module list — the tick
+        container has no access to the app that configured it."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-tick",
+            task_modules=[SyncOnlyTask.__module__],
+            require_pickle_free=True,
+        )
+        registered = _finalize_capturing_functions(app)
+
+        with patch("stardag.integration.modal._app._run_tick") as run_tick:
+            run_tick.return_value = {}
+            registered["tick"](str(uuid4()), None)
+
+        assert run_tick.call_args.kwargs["deployment"].require_pickle_free is True
+
+    def test_an_ordinary_app_deploys_a_writing_tick(self):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-tick-off", task_modules=[SyncOnlyTask.__module__]
+        )
+        registered = _finalize_capturing_functions(app)
+
+        with patch("stardag.integration.modal._app._run_tick") as run_tick:
+            run_tick.return_value = {}
+            registered["tick"](str(uuid4()), None)
+
+        assert run_tick.call_args.kwargs["deployment"].require_pickle_free is False
+
+
+class TestTickTaskStoreIsPickleFree:
+    """...and the tick builds its store from that flag.
+
+    Split from the test above because the two halves fail independently: a
+    flag that is carried but never read looks exactly like a fix.
+    """
+
+    def _run_tick_capturing_store(self, *, require_pickle_free: bool):
+        from stardag.integration.modal import _tick as tick_module
+
+        deployment = tick_module._TickDeployment(
+            app_name="tm-tick-store",
+            worker_selector=lambda task: "default",
+            limit_key_selector=None,
+            modal_workspace=None,
+            worker_timeouts={},
+            tick_timeout_seconds=None,
+            task_modules=(),
+            task_module_patterns=(),
+            require_pickle_free=require_pickle_free,
+        )
+        registry = MagicMock(spec=RegistryABC)
+        # Not reactively scheduled: _run_tick returns before it schedules
+        # anything, but only AFTER constructing the store — which is all
+        # this asserts on.
+        registry.build_get.return_value = MagicMock(reactive_app_name=None)
+        stores: list = []
+        real_store = tick_module.BuildTaskStore
+
+        def capture(*args, **kwargs):
+            store = real_store(*args, **kwargs)
+            stores.append(store)
+            return store
+
+        with patch.object(tick_module, "BuildTaskStore", capture):
+            with registry_provider.override(registry):
+                tick_module._run_tick(str(uuid4()), None, deployment=deployment)
+        assert len(stores) == 1
+        return stores[0]
+
+    def test_a_declaring_app_gets_a_refusing_store(self):
+        assert self._run_tick_capturing_store(require_pickle_free=True).pickle_free
+
+    def test_an_ordinary_app_gets_the_store_it_always_had(self):
+        assert not self._run_tick_capturing_store(require_pickle_free=False).pickle_free
+
 
 class TestDynamicDepPickleElision:
     """Dynamic deps registered from inside a worker get the same treatment —


### PR DESCRIPTION
Closes STA-27.

## Problem

`require_pickle_free=True` was a **trigger-time gate**: `_bootstrap.py`
calls `plan.require_pickle_free_error()` before the build starts and
refuses to trigger if any task would need a pickle. Nothing carried the
flag any further.

But the bootstrap is not the only writer of the build task store. A
scheduler tick is one too — `_load_task` rehydrates a task from registry
data and then writes it straight back:

```python
logger.info(f"Rehydrated task {task_id} from registry data.")
try:
    await task_store.save_task_aio(task)
except Exception as e:
    logger.warning(f"Failed to write rehydrated task {task_id} back: {e}")
```

Two things were tangled here, and the less visible one is the more
serious.

**The quiet half is the bug.** On a writable target root with picklable
task classes, the write-back succeeds. A build that declared
`require_pickle_free=True` then leaves pickles on the target root anyway
— exactly what someone sets the flag to prevent, whether for an
immutable/append-only root or because a redeploy makes stored pickles a
liability. Nothing surfaces it; the pickles are simply there. `save_task`
is write-once, so it happens on the first rehydration of each task — but
"only sometimes writes a file you asked it never to write" is not a
defence.

**The loud half is harmless, and is how this was found.** Where the class
cannot be pickled by reference the write fails, warns once per
rehydration per tick, and the build carries on correctly — rehydration
had already returned the object. Observed in the tick logs of a
registry-live harness whose tasks are decorator-built, so the generated
class name and the module attribute differ:

```
INFO:...:Rehydrated task 28a51a7b-... from registry data.
WARNING:...:Failed to write rehydrated task 28a51a7b-... back:
  Can't pickle <class '....tasks.Sum'>: attribute lookup Sum on ....tasks failed
```

The mismatch is incidental — it made the behaviour audible, it is not the
cause. The cost of the noise is real though: it competes with signal in
CI, on the very configuration the feature recommends.

## Fix

`BuildTaskStore` gains `pickle_free`, which makes every write a no-op,
and the deployed tick builds its store from the app's flag — carried on
`_TickDeployment`, deploy-time like the module list beside it and for the
same reason: the flag describes the *deployment*, and the trigger's own
copy is the caller's local app definition rather than the one the ticks
were built from.

**Why the store and not an argument.** The writers are spread across the
trigger, the workers and the tick; the one that leaked sits several
frames below anything that knows what the build declared. A store that
refuses is the single place all writers pass through. `save_task` /
`save_task_aio` hold the guard and delegate to a `_write_task` hook, so
subclasses — including the test double — inherit it rather than
bypassing it.

**Nothing is lost by skipping.** The write-back is a cache over an object
the caller already holds, and on such a build every task is rehydratable
by construction. `Rehydrated task ...` also drops to DEBUG there: it is
the designed path for every task on every tick, not an exception worth an
INFO line. (Same reasoning that demoted the store-miss log.)

## Deliberately unchanged

Both now documented where they are decided, so neither reads as an
oversight:

- **The bootstrap keeps a writing store.** Its gate *is* the enforcement
  and it is exact — it names the offending tasks and fails the build. A
  silently-dropping store there would, if the gate ever stopped firing
  first, turn a loud start-time failure into a stall at "could not
  rehydrate". The tick has no such gate and nothing to lose.
- **An uncovered *dynamic* dependency still gets its pickle.** Registered
  from inside a worker whose task has already run; failing its bookkeeping
  to enforce a storage preference would be the worse outcome. This carve-out
  was already documented and is now stated in the how-to too, so the flag's
  promise is accurate rather than absolute.

## Tests

- `test_task_store.py` — a pickle-free store writes nothing through
  `save_task`, `save_task_aio` or `save_tasks`, and says so only at DEBUG;
  the default store still writes.
- `test_reactive_frontier_actions.py` — a full tick over a
  decorator-built DAG on a pickle-free store: the task is still rehydrated
  and spawned, nothing lands in the store, no WARNING is logged, and
  rehydration is DEBUG. Plus the converse: an ordinary build still caches.
- `test_stardag_app.py` — the flag reaches the deployed tick's closure,
  and `_run_tick` builds its store from it. Split in two on purpose: a
  flag that is carried but never read looks exactly like a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)