### PR TITLE
Ticks share a container: async tick, concurrent inputs by default

### DIFF
--- a/.github/workflows/modal-live.yml
+++ b/.github/workflows/modal-live.yml
@@ -247,7 +247,16 @@ jobs:
           # what it wanted.
           elif uvx modal environment create "$name" 2>&1 | tee /tmp/create.log; then
             echo "Created '$name'."
-          elif grep -qi "already exists" /tmp/create.log; then
+          # Re-ask, rather than matching the error text. The first version
+          # of this grepped for "already exists", which Modal has never
+          # said — it says "Can not create an environment with the same
+          # name or web label suffix as an existing one" — so the race
+          # guard above it never actually fired, and the first PR to run
+          # both tiers together failed here. What the guard wants to know
+          # is whether the environment exists now, which the list answers
+          # directly and no vendor rewording can break.
+          elif uvx modal environment list --json | jq -e --arg n "$name" \
+                 'any(.[]; .name == $n)' > /dev/null; then
             echo "Environment '$name' was created concurrently."
           else
             cat /tmp/create.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   old one.** `max_containers`, `min_containers`, `buffer_containers`,
   `scaledown_window`, `max_concurrent_inputs` and `target_concurrent_inputs`
   are now accepted; the last two are applied via `@modal.concurrent` rather
-  than passed to `App.function()`. The four legacy names Modal renamed in 2025
+  than passed to `App.function()`, and validated in stardag's own vocabulary
+  rather than left to fail at registration with a `TypeError` naming a
+  parameter nobody wrote. The four legacy names Modal renamed in 2025
   — `concurrency_limit`, `keep_warm`, `container_idle_timeout` and
   `allow_concurrent_inputs` — are translated with a warning instead of being
   forwarded. This is a **bug fix, not a deprecation**: Modal's client raises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **Scheduler ticks share a container.** The deployed Modal `tick` is now an
+  `async def` and is registered with `max_concurrent_inputs=10`, so up to ten
+  concurrent reactive builds are served by one container instead of one each.
+  A tick is almost entirely I/O wait — read the frontier, spawn, then poll on
+  a sleep until the linger deadline — so this is close to free, and it is what
+  makes `linger_seconds` cheap: a resident tick driving level after level no
+  longer costs a container of its own. Async is load-bearing rather than
+  stylistic: Modal serves concurrent inputs to a sync function on _threads_,
+  each running its own `asyncio.run`, and `APIRegistry`'s async client is
+  cached per event loop and closed when the loop changes — so threaded ticks
+  would tear down each other's in-flight HTTP client. Workers are deliberately
+  not packed (they run user code and may be CPU- or GPU-bound), nor is
+  `tick_watchdog` (its own function, one input per period). Supporting
+  changes: the async client's connection pool is sized for a shared process
+  rather than for one caller, and the tick's two remaining blocking calls —
+  the foreign-app forward and the successor hand-off's spawn — moved off the
+  event loop, where they would have stalled every co-resident tick.
+- **`FunctionSettings` speaks Modal's current vocabulary, and translates the
+  old one.** `max_containers`, `min_containers`, `buffer_containers`,
+  `scaledown_window`, `max_concurrent_inputs` and `target_concurrent_inputs`
+  are now accepted; the last two are applied via `@modal.concurrent` rather
+  than passed to `App.function()`. The four legacy names Modal renamed in 2025
+  — `concurrency_limit`, `keep_warm`, `container_idle_timeout` and
+  `allow_concurrent_inputs` — are translated with a warning instead of being
+  forwarded. This is a **bug fix, not a deprecation**: Modal's client raises
+  `DeprecationError` on all four, and `FunctionSettings` passed them straight
+  through, so any app that set one failed to deploy.
+
 - **`require_pickle_free=True` now binds the scheduler tick, not just the
   trigger.** The flag was a trigger-time gate: the bootstrap refused to start
   a build whose tasks would need pickles, and nothing carried the intent any

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -166,8 +166,8 @@ holding a slot leaves its task `RUNNING` until the claim lapses; reactive
 scheduling on Modal heals this itself, which is one reason to prefer it
 for unattended limited runs.
 
-Infrastructure-level limits (Modal's per-function `concurrency_limit`,
-say) apply independently underneath.
+Infrastructure-level limits (Modal's per-function `max_containers`, say)
+apply independently underneath.
 
 ### Global concurrency lock (deprecated)
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -462,6 +462,12 @@ A worker that opts in must be safe to run **concurrently on threads** —
 Modal serves concurrent inputs to a sync function that way, and to an
 `async def` as asyncio tasks on one event loop.
 
+`target_concurrent_inputs` is the concurrency Modal's autoscaler _aims_
+for below the ceiling, so it requires `max_concurrent_inputs` alongside
+it; setting it alone is refused at deploy. Note also that `tick_settings`
+registers both `tick` and `tick_watchdog`, but a concurrency declared
+there applies only to the tick — the watchdog is sync and never packed.
+
 **Per-build knobs** (`tick_kwargs`, persisted with the build so every tick
 shares them): `linger_seconds` (default 120), `poll_interval_seconds` (3),
 `fail_mode`, `max_attempts` (2), `max_interruptions` (20),

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -439,6 +439,29 @@ Set an explicit worker `timeout`: the execution claim's TTL is derived
 from it, which is what lets other builds tell an abandoned claim from a
 live one, and what keeps a live claim from being taken early.
 
+**Ticks share containers.** A tick is almost entirely I/O wait — read the
+frontier, spawn, then poll on a sleep until its linger deadline — so the
+deployed `tick` is registered with `max_concurrent_inputs=10` and one
+container serves up to ten concurrent reactive builds. That is what makes
+`linger_seconds` cheap: a resident tick driving level after level no
+longer costs a container of its own.
+
+Nothing else is packed by default. Workers run your code and may be CPU-
+or GPU-bound; the builder runs a whole build; the bootstrap walks a DAG.
+Override per function where you know better:
+
+```{.python notest}
+tick_settings=sd_modal.FunctionSettings(image=image, max_concurrent_inputs=32),
+# ...or opt an I/O-bound worker in:
+worker_settings={
+    "fetch": sd_modal.FunctionSettings(image=image, max_concurrent_inputs=8),
+},
+```
+
+A worker that opts in must be safe to run **concurrently on threads** —
+Modal serves concurrent inputs to a sync function that way, and to an
+`async def` as asyncio tasks on one event loop.
+
 **Per-build knobs** (`tick_kwargs`, persisted with the build so every tick
 shares them): `linger_seconds` (default 120), `poll_interval_seconds` (3),
 `fail_mode`, `max_attempts` (2), `max_interruptions` (20),

--- a/integration-tests/src/stardag_integration_tests/registry_live/_harness.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_harness.py
@@ -301,8 +301,8 @@ def stop_existing_app(app_name: str, modal_environment: str) -> None:
         return
 
     output = ((result.stderr or "") + (result.stdout or "")).strip()
-    if _looks_like_no_such_app(output):
-        print(f"[harness] no previous {app_name!r} to stop")
+    if _looks_like_nothing_to_stop(output):
+        print(f"[harness] no running {app_name!r} to stop")
         return
 
     # Anything else is a real failure and must not be swallowed. Treating
@@ -316,8 +316,13 @@ def stop_existing_app(app_name: str, modal_environment: str) -> None:
     )
 
 
-def _looks_like_no_such_app(output: str) -> bool:
-    """Whether Modal's complaint means "there is nothing deployed here".
+def _looks_like_nothing_to_stop(output: str) -> bool:
+    """Whether Modal's complaint means "there is nothing running here".
+
+    Two ways to already be in the state this function wants: no such app,
+    and an app that is already stopped. Both satisfy what the caller
+    actually needs — no survivor serving the previous run's data or code,
+    and no warm container holding a since-rotated API key.
 
     Matched on text because the CLI exits 1 for both this and real errors.
     Deliberately narrow: an unrecognised message is treated as a failure,
@@ -343,6 +348,14 @@ def _looks_like_no_such_app(output: str) -> bool:
             # one of those turns this helper back into the no-op it once
             # silently was.
             "no such app",
+            # An app that has been stopped already. Reached on the *second*
+            # run against a reused environment — the per-PR environment
+            # outlives a run and is deleted only when the PR closes, so the
+            # previous run's teardown (or its cancellation) leaves the app
+            # stopped and the next run found that fatal. "Already in the
+            # state I was asked to put it in" is success, exactly as it is
+            # for the environment-create race in `modal-live.yml`.
+            "already stopped",
         )
     )
 

--- a/lib/stardag/src/stardag/build/_reactive/_tick.py
+++ b/lib/stardag/src/stardag/build/_reactive/_tick.py
@@ -566,12 +566,16 @@ async def _hand_off_if_needed(
             # guessing one would be worse than leaving the flag for the
             # next completion or the watchdog.
             return
-        # Sync call in async code, on purpose: spawning is what every
-        # executor integration offers, this is the last thing the tick does
-        # (the lease is released, its renewal task cancelled, nothing else
-        # is in flight), and requiring an async spawner would exclude the
-        # integrations that only have a blocking one.
-        spawn(build_id, info.reactive_app_name)
+        # Blocking spawner in async code, so off the loop: spawning is what
+        # every executor integration offers, and requiring an async spawner
+        # would exclude the ones that only have a blocking call. It used to
+        # run inline, justified by "the last thing the tick does — lease
+        # released, renewal cancelled, nothing else in flight". True of the
+        # tick; false of its *container*, once ticks share one (see the
+        # Modal integration's ``_TICK_CONCURRENCY``), where an inline
+        # backend RPC stalls every co-resident tick's polling.
+        # ``drain_wake_candidates`` already spawns this way.
+        await asyncio.to_thread(spawn, build_id, info.reactive_app_name)
         summary.successor_spawned += 1
         logger.info(
             "Build %s was notified while this tick released the scheduler "

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -963,6 +963,7 @@ class StardagApp:
             settings: FunctionSettings,
             *,
             default_concurrency: InputConcurrency | None = None,
+            never_concurrent: bool = False,
             **extra: typing.Any,
         ):
             """Register one function on the Modal app under ``name``.
@@ -971,6 +972,13 @@ class StardagApp:
             particular function should be packed, applied only when the
             app's own settings say nothing — see the ``tick`` registration
             below, which is the one function that has one.
+
+            ``never_concurrent`` refuses input concurrency for this
+            function whatever the settings say. Needed because settings
+            are shared: ``tick`` and ``tick_watchdog`` are registered from
+            one ``tick_settings``, so an app that packs its tick would
+            otherwise pack a sync watchdog too — onto Modal's *threads*,
+            which is the hazard the async tick exists to avoid.
             """
             prepared = _prepare_function_settings(
                 settings,
@@ -983,7 +991,11 @@ class StardagApp:
             # Input concurrency is a decorator rather than a `function()`
             # keyword (Modal moved it in April 2025), so it is applied to
             # the callable first and `function()` registers the result.
-            concurrency = prepared.concurrency or default_concurrency
+            concurrency = (
+                None
+                if never_concurrent
+                else prepared.concurrency or default_concurrency
+            )
             if concurrency is None:
                 return decorate
 
@@ -1171,20 +1183,23 @@ class StardagApp:
             # where each tick is spawned — see _run_watchdog_sweep.
             _run_watchdog_sweep(registry_provider.get(), app_name)
 
-        # Deliberately no `default_concurrency`, even though it shares
-        # `tick_settings` with the tick: this is its own Modal function with
-        # its own containers, receiving one input per watchdog period, so
-        # packing would change nothing in the steady state — while quietly
-        # opting a `def` into Modal's *threaded* concurrency, which is the
-        # hazard `_modal_tick` is a coroutine to avoid.
+        # `never_concurrent`, not merely "no default": it shares
+        # `tick_settings` with the tick, so a declared value would reach it
+        # too. This is its own Modal function with its own containers,
+        # receiving one input per watchdog period, so packing would change
+        # nothing in the steady state — while quietly opting a `def` into
+        # Modal's *threaded* concurrency, which is the hazard
+        # `_modal_tick` is a coroutine to avoid. Modal accepts a sync
+        # function with `@modal.concurrent` and a `schedule` without
+        # complaint, so nothing downstream would have caught it.
         watchdog_schedule: dict[str, typing.Any] = (
             {"schedule": modal.Period(minutes=self.watchdog_period_minutes)}
             if self.watchdog_period_minutes is not None
             else {}
         )
-        register("tick_watchdog", tick_settings, **watchdog_schedule)(
-            _modal_tick_watchdog
-        )
+        register(
+            "tick_watchdog", tick_settings, never_concurrent=True, **watchdog_schedule
+        )(_modal_tick_watchdog)
         function_names.append("tick_watchdog")
 
         self._is_finalized = True

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -65,12 +65,13 @@ from stardag.integration.modal._selector import (
 )
 from stardag.integration.modal._settings import (
     FunctionSettings,
+    InputConcurrency,
     _prepare_function_settings,
 )
 from stardag.integration.modal._target import get_default_volume_mount_path
 from stardag.integration.modal._tick import (
     LimitKeySelector,
-    _run_tick,
+    _run_deployed_tick_aio,
     _run_watchdog_sweep,
     _tick_function_timeout_seconds,
     _TickDeployment,
@@ -84,6 +85,38 @@ from stardag.registry._base import NoOpRegistry, registry_provider
 from stardag.utils.env import temp_env_vars
 
 logger = logging.getLogger(__name__)
+
+
+# How many scheduler ticks one container may serve at once, unless the app
+# says otherwise via ``tick_settings``.
+#
+# **Why the tick and nothing else.** A tick is almost entirely I/O wait: it
+# reads the frontier, spawns, and then polls on a sleep until its linger
+# deadline. One container per tick is therefore close to the worst possible
+# packing — and the linger that makes reactive scheduling efficient (one
+# resident scheduler driving level after level, instead of a cold start per
+# level) is precisely what keeps those containers alive. Sharing makes the
+# linger nearly free. No other function in the app has that shape: workers
+# run user code and may be CPU- or GPU-bound, the builder runs a whole
+# build, and the bootstrap walks a DAG.
+#
+# **Not ``tick_watchdog``**, even though it shares ``tick_settings``. It is
+# a separate Modal function with its own containers and receives one input
+# per ``watchdog_period_minutes``, so concurrency would change nothing in
+# the steady state; and it is a ``def``, which Modal would serve on
+# threads — the exact hazard ``_modal_tick`` is async to avoid.
+#
+# **Why 10, and why bounded at all.** Concurrency is not free per tick: each
+# holds a ``BuildTaskStore``, up to ``TickConfig.max_concurrent_actions``
+# in-flight registry calls, and a share of one HTTP connection pool (see
+# ``APIRegistry``'s async limits, sized against this number). Ten is enough
+# that the linger stops driving container count at the scale reactive builds
+# actually run at, and small enough that one container's loss is bounded.
+#
+# ``target_inputs`` is deliberately unset: it would have Modal provision a
+# further container rather than pack up to the max, which is the opposite of
+# the point here.
+_TICK_CONCURRENCY: InputConcurrency = {"max_inputs": 10}
 
 
 class FinalizeResult(typing.NamedTuple):
@@ -925,16 +958,39 @@ class StardagApp:
         task_module_patterns = self.task_modules
         task_modules = expand_task_module_patterns(task_module_patterns)
 
-        def register(name: str, settings: FunctionSettings, **extra: typing.Any):
-            """Register one function on the Modal app under ``name``."""
+        def register(
+            name: str,
+            settings: FunctionSettings,
+            *,
+            default_concurrency: InputConcurrency | None = None,
+            **extra: typing.Any,
+        ):
+            """Register one function on the Modal app under ``name``.
+
+            ``default_concurrency`` is stardag's opinion about how this
+            particular function should be packed, applied only when the
+            app's own settings say nothing — see the ``tick`` registration
+            below, which is the one function that has one.
+            """
             prepared = _prepare_function_settings(
                 settings,
                 extra_secrets=extra_secrets,
                 auto_volumes=auto_volumes,
             )
-            return self.modal_app.function(
-                **{**prepared, "name": name, "serialized": True, **extra}
+            decorate = self.modal_app.function(
+                **{**prepared.kwargs, "name": name, "serialized": True, **extra}
             )
+            # Input concurrency is a decorator rather than a `function()`
+            # keyword (Modal moved it in April 2025), so it is applied to
+            # the callable first and `function()` registers the result.
+            concurrency = prepared.concurrency or default_concurrency
+            if concurrency is None:
+                return decorate
+
+            def decorate_concurrent(fn):
+                return decorate(modal.concurrent(**concurrency)(fn))
+
+            return decorate_concurrent
 
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
@@ -1002,7 +1058,7 @@ class StardagApp:
         # safe to invoke at any time; no-ops on non-reactive builds.
         #
         # Everything the deployed tick needs from deploy time is bundled
-        # here and closed over; the body lives in _tick._run_tick.
+        # here and closed over; the body lives in _tick._run_deployed_tick_aio.
         app_name = self.name
         tick_deployment = _TickDeployment(
             app_name=app_name,
@@ -1021,18 +1077,32 @@ class StardagApp:
             require_pickle_free=self.require_pickle_free,
         )
 
-        def _modal_tick(
+        # ``async def`` on purpose, and load-bearing. Modal serves
+        # concurrent inputs to an async function as asyncio tasks on ONE
+        # event loop, and to a sync one on threads — and a tick on its own
+        # thread would run its own ``asyncio.run``, i.e. its own loop.
+        # ``APIRegistry`` is a process-wide singleton whose ``async_client``
+        # is cached per loop and *closed and rebuilt* whenever the running
+        # loop differs, so two threaded ticks would tear down each other's
+        # in-flight HTTP client. Awaiting the body here keeps every tick in
+        # the container on one loop and therefore on one client, which is
+        # what makes sharing a container safe rather than merely allowed.
+        async def _modal_tick(
             build_id: str,
             tick_kwargs: dict[str, typing.Any] | None = None,
         ) -> dict[str, typing.Any]:
             _run_container_setup(container_setup)
-            return _run_tick(build_id, tick_kwargs, deployment=tick_deployment)
+            return await _run_deployed_tick_aio(
+                build_id, tick_kwargs, deployment=tick_deployment
+            )
 
         # tick/watchdog default to builder_settings when tick_settings is
         # not given; the api-key secret is in extra_secrets so they get
         # registry credentials regardless of which settings apply.
         tick_settings = self._tick_settings or self._builder_settings
-        register("tick", tick_settings)(_modal_tick)
+        register("tick", tick_settings, default_concurrency=_TICK_CONCURRENCY)(
+            _modal_tick
+        )
         function_names.append("tick")
 
         # Reactive bootstrap (see run_reactive_bootstrap). Spawned by
@@ -1101,15 +1171,20 @@ class StardagApp:
             # where each tick is spawned — see _run_watchdog_sweep.
             _run_watchdog_sweep(registry_provider.get(), app_name)
 
-        register(
-            "tick_watchdog",
-            tick_settings,
-            **(
-                {"schedule": modal.Period(minutes=self.watchdog_period_minutes)}
-                if self.watchdog_period_minutes is not None
-                else {}
-            ),
-        )(_modal_tick_watchdog)
+        # Deliberately no `default_concurrency`, even though it shares
+        # `tick_settings` with the tick: this is its own Modal function with
+        # its own containers, receiving one input per watchdog period, so
+        # packing would change nothing in the steady state — while quietly
+        # opting a `def` into Modal's *threaded* concurrency, which is the
+        # hazard `_modal_tick` is a coroutine to avoid.
+        watchdog_schedule: dict[str, typing.Any] = (
+            {"schedule": modal.Period(minutes=self.watchdog_period_minutes)}
+            if self.watchdog_period_minutes is not None
+            else {}
+        )
+        register("tick_watchdog", tick_settings, **watchdog_schedule)(
+            _modal_tick_watchdog
+        )
         function_names.append("tick_watchdog")
 
         self._is_finalized = True

--- a/lib/stardag/src/stardag/integration/modal/_settings.py
+++ b/lib/stardag/src/stardag/integration/modal/_settings.py
@@ -3,15 +3,30 @@
 :class:`FunctionSettings` is what a user writes when configuring an app's
 builder/worker/tick functions. :func:`_prepare_function_settings` is what
 :meth:`stardag.integration.modal.StardagApp.finalize` applies to it before
-handing the result to ``modal.App.function()``.
+handing the result to Modal — as a :class:`PreparedFunction`, because a
+declaration reaches Modal through two doors rather than one: see below.
+
+**These settings are not a pass-through, and cannot be.** Modal renamed
+three container-scaling parameters in February 2025 and moved input
+concurrency out of ``function()`` into the ``@modal.concurrent`` decorator
+in April 2025, and its client *raises* on the old spellings rather than
+warning. A ``FunctionSettings`` carrying one of them is therefore a failed
+deploy, not a deprecation notice. So this module owns the vocabulary:
+current Modal names are what a user should write, the four legacy names are
+accepted and translated (see :data:`_RENAMED_SETTINGS`), and the two
+concurrency keys are lifted out of the ``function()`` kwargs and returned
+beside them for the decorator.
 """
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import typing
 
 import modal
+
+logger = logging.getLogger(__name__)
 
 
 class FunctionSettings(typing.TypedDict, total=False):
@@ -37,10 +52,27 @@ class FunctionSettings(typing.TypedDict, total=False):
             unset, ``timeout`` covers both.
         volumes: Dict of mount path to Volume or CloudBucketMount.
         secrets: List of Modal secrets to inject.
-        concurrency_limit: Max number of concurrent containers.
-        allow_concurrent_inputs: Max concurrent inputs per container.
-        container_idle_timeout: Seconds before idle container shuts down.
-        keep_warm: Number of containers to keep warm.
+        max_containers: Ceiling on how many containers this function may
+            scale out to.
+        min_containers: Containers kept warm regardless of load.
+        buffer_containers: Extra idle containers kept ready above current
+            demand, to absorb a burst without a cold start.
+        scaledown_window: Seconds an idle container is kept before it is
+            shut down.
+        max_concurrent_inputs: How many inputs one container may serve at
+            once. **Only safe on a function whose body is safe to run
+            concurrently**, and what "concurrently" means depends on the
+            function: Modal serves an ``async def`` as asyncio tasks on one
+            event loop, and a ``def`` on threads, which is the harder
+            contract. Stardag defaults this for the reactive ``tick``
+            (async, and almost entirely I/O wait) and deliberately not for
+            workers, which run user code — see ``StardagApp.finalize``.
+        target_concurrent_inputs: The per-container concurrency Modal's
+            autoscaler *aims* for, below ``max_concurrent_inputs``, which
+            containers may burst past when demand outruns supply. Trades a
+            little average latency for smaller tail latencies. Leaving it
+            unset maximises packing, which is usually what you want for an
+            I/O-bound function.
         ephemeral_disk: Ephemeral disk size in MB.
         retries: Number of retries on failure. Covers exceptions raised
             *inside* the container and function timeouts; it is not what
@@ -55,6 +87,11 @@ class FunctionSettings(typing.TypedDict, total=False):
             that genuinely cannot checkpoint. Modal client >= 1.2.3;
             carries a 3x price multiplier on CPU and memory, and is not
             supported for GPU functions.
+        concurrency_limit: Deprecated alias for ``max_containers``.
+        keep_warm: Deprecated alias for ``min_containers``.
+        container_idle_timeout: Deprecated alias for ``scaledown_window``.
+        allow_concurrent_inputs: Deprecated alias for
+            ``max_concurrent_inputs``.
     """
 
     image: typing.Required[modal.Image]
@@ -68,13 +105,108 @@ class FunctionSettings(typing.TypedDict, total=False):
         typing.Union[modal.Volume, modal.CloudBucketMount],
     ]
     secrets: list[modal.Secret]
-    concurrency_limit: int
-    allow_concurrent_inputs: int
-    container_idle_timeout: int
-    keep_warm: int
+    max_containers: int
+    min_containers: int
+    buffer_containers: int
+    scaledown_window: int
+    max_concurrent_inputs: int
+    target_concurrent_inputs: int
     ephemeral_disk: int
     retries: int
     nonpreemptible: bool
+    # Legacy Modal spellings, translated at deploy — see _RENAMED_SETTINGS.
+    concurrency_limit: int
+    keep_warm: int
+    container_idle_timeout: int
+    allow_concurrent_inputs: int
+
+
+_RENAMED_SETTINGS: dict[str, str] = {
+    # Renamed by Modal on 2025-02-24.
+    "concurrency_limit": "max_containers",
+    "keep_warm": "min_containers",
+    "container_idle_timeout": "scaledown_window",
+    # Moved out of `function()` into `@modal.concurrent` on 2025-04-09; the
+    # stardag name keeps "max" in front for the same reason Modal's
+    # `max_inputs=` does, and because `allow_…` reads like a boolean.
+    "allow_concurrent_inputs": "max_concurrent_inputs",
+}
+"""Legacy Modal parameter names accepted in :class:`FunctionSettings`.
+
+Translated rather than rejected, and translated silently enough to be
+worth spelling out: every one of these was a **hard error** from Modal
+≥1.0 — its client raises ``DeprecationError`` from ``function()`` instead
+of warning — so an app that sets one does not deploy at all today. There
+is no behaviour anyone can be relying on, which makes translation pure
+gain and makes a one-line warning the right volume for it.
+"""
+
+
+# stardag's own names for the two `@modal.concurrent` arguments, and the
+# Modal ones they map to. Kept apart from _RENAMED_SETTINGS because these
+# are not renames: they are settings that stop being `function()` keywords
+# and become a decorator, which is a different edit to make on the way out.
+_CONCURRENCY_SETTINGS: dict[str, str] = {
+    "max_concurrent_inputs": "max_inputs",
+    "target_concurrent_inputs": "target_inputs",
+}
+
+
+InputConcurrency = dict[str, int]
+"""Keyword arguments for ``modal.concurrent`` — ``max_inputs``/``target_inputs``."""
+
+
+def _normalize_legacy_names(settings: typing.Mapping[str, typing.Any]) -> dict:
+    """Rewrite any legacy Modal parameter names to their current spelling.
+
+    Warns once per call site rather than raising: the alternative is the
+    ``DeprecationError`` Modal itself throws, which is what this exists to
+    prevent. An explicit current-name value wins over a legacy one — the
+    two would otherwise resolve by dict order, which is not a rule anyone
+    should have to know.
+    """
+    result = dict(settings)
+    for legacy, current in _RENAMED_SETTINGS.items():
+        if legacy not in result:
+            continue
+        value = result.pop(legacy)
+        if current in result:
+            logger.warning(
+                "Modal function settings declare both %r and its current "
+                "name %r; using %r=%r and ignoring %r.",
+                legacy,
+                current,
+                current,
+                result[current],
+                legacy,
+            )
+            continue
+        logger.warning(
+            "Modal function setting %r has been renamed to %r; stardag is "
+            "translating it, but please update the declaration.",
+            legacy,
+            current,
+        )
+        result[current] = value
+    return result
+
+
+def _input_concurrency(
+    normalized: typing.Mapping[str, typing.Any],
+) -> InputConcurrency | None:
+    """The ``modal.concurrent`` arguments a normalized declaration carries.
+
+    ``None`` when it carries none — which is not the same as
+    ``max_inputs=1``. Modal's decorator changes how a container serves
+    inputs at all, so a function that never asks for concurrency should not
+    be wrapped in it.
+    """
+    concurrency: InputConcurrency = {
+        modal_name: normalized[stardag_name]
+        for stardag_name, modal_name in _CONCURRENCY_SETTINGS.items()
+        if normalized.get(stardag_name) is not None
+    }
+    return concurrency or None
 
 
 def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
@@ -96,20 +228,49 @@ def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
     return result
 
 
+class PreparedFunction(typing.NamedTuple):
+    """One ``FunctionSettings`` resolved into the two things Modal needs.
+
+    Two, and not one, because Modal takes them through different doors:
+    ``kwargs`` goes to ``modal.App.function()`` and ``concurrency`` — when
+    the declaration asks for any — to ``@modal.concurrent``. Returning them
+    together is what keeps a single declaration from being read twice and
+    from being half-applied.
+
+    Attributes:
+        kwargs: Keyword arguments for ``modal.App.function()``.
+        concurrency: Keyword arguments for ``modal.concurrent``, or None
+            when this function declared no input concurrency.
+    """
+
+    kwargs: dict[str, typing.Any]
+    concurrency: InputConcurrency | None
+
+
 def _prepare_function_settings(
     settings: FunctionSettings,
     *,
     extra_secrets: list[modal.Secret],
     auto_volumes: dict[str, modal.Volume],
-) -> dict[str, typing.Any]:
-    """Merge extra secrets and auto-volumes into function settings.
+) -> PreparedFunction:
+    """Resolve ``settings`` into what ``StardagApp.finalize`` hands Modal.
 
     Auto-mounted volumes are merged with user volumes, where user-specified
     volumes at the same mount path take precedence over auto-mounted ones.
     Secrets are de-duplicated by name (a named secret propagated from the
     builder plus one the function already declares should apply once).
+
+    Legacy parameter names are translated to their current spelling here —
+    once, which is why this is the only public way in: normalizing in two
+    places would warn twice about the same declaration. The
+    input-concurrency settings are then lifted out of the ``function()``
+    kwargs, because they are not ``function()`` keywords at all.
     """
-    result: dict[str, typing.Any] = dict(settings)
+    normalized = _normalize_legacy_names(settings)
+    concurrency = _input_concurrency(normalized)
+    result: dict[str, typing.Any] = normalized
+    for stardag_name in _CONCURRENCY_SETTINGS:
+        result.pop(stardag_name, None)
 
     # Merge secrets: existing + extra, de-duplicated by name.
     existing_secrets: list[modal.Secret] = list(result.get("secrets") or [])
@@ -119,4 +280,4 @@ def _prepare_function_settings(
     user_volumes = dict(result.get("volumes") or {})
     result["volumes"] = {**auto_volumes, **user_volumes}
 
-    return result
+    return PreparedFunction(kwargs=result, concurrency=concurrency)

--- a/lib/stardag/src/stardag/integration/modal/_settings.py
+++ b/lib/stardag/src/stardag/integration/modal/_settings.py
@@ -26,6 +26,8 @@ import typing
 
 import modal
 
+from stardag.exceptions import StardagError
+
 logger = logging.getLogger(__name__)
 
 
@@ -206,7 +208,40 @@ def _input_concurrency(
         for stardag_name, modal_name in _CONCURRENCY_SETTINGS.items()
         if normalized.get(stardag_name) is not None
     }
-    return concurrency or None
+    if not concurrency:
+        return None
+    _validate_input_concurrency(concurrency)
+    return concurrency
+
+
+def _validate_input_concurrency(concurrency: InputConcurrency) -> None:
+    """Reject a concurrency declaration Modal will refuse, in stardag's words.
+
+    Both of these are caught by Modal too — but at *registration*, and
+    phrased in its own parameter names, which are not the ones the user
+    wrote. ``max_concurrent_inputs=…`` producing a ``TypeError`` about a
+    missing ``max_inputs`` is a bad way to learn this, so the settings
+    module that owns the renaming owns the error message too.
+    """
+    if "max_inputs" not in concurrency:
+        raise StardagError(
+            "FunctionSettings sets target_concurrent_inputs="
+            f"{concurrency['target_inputs']} without max_concurrent_inputs. "
+            "A target is the concurrency Modal's autoscaler aims for "
+            "*below* a ceiling, so it is meaningless on its own and Modal "
+            "refuses the function. Set max_concurrent_inputs as well — and "
+            "note that stardag's own default for the reactive tick is not "
+            "merged in underneath, because a ceiling nobody asked for is "
+            "not a safe thing to invent."
+        )
+    if (target := concurrency.get("target_inputs")) is not None:
+        if target > concurrency["max_inputs"]:
+            raise StardagError(
+                f"FunctionSettings sets target_concurrent_inputs={target} "
+                f"above max_concurrent_inputs={concurrency['max_inputs']}. "
+                "The target is what the autoscaler aims for below the "
+                "ceiling; it cannot exceed it."
+            )
 
 
 def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:

--- a/lib/stardag/src/stardag/integration/modal/_tick.py
+++ b/lib/stardag/src/stardag/integration/modal/_tick.py
@@ -9,7 +9,7 @@ The tick is deployed as a Modal function, so it runs in a container with no
 access to the ``StardagApp`` object that configured it. Everything it needs
 from deploy time is therefore captured in a :class:`_TickDeployment` at
 ``finalize()`` and closed over by the registered wrapper — which keeps that
-wrapper a two-line delegation to :func:`_run_tick` here.
+wrapper a two-line delegation to :func:`_run_deployed_tick_aio` here.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import os
 import typing
 from uuid import UUID
 
@@ -261,7 +262,7 @@ class _TickDeployment:
     require_pickle_free: bool
 
 
-def _run_tick(
+async def _run_deployed_tick_aio(
     build_id: str,
     tick_kwargs: dict[str, typing.Any] | None = None,
     *,
@@ -276,6 +277,21 @@ def _run_tick(
     ``run_tick_aio`` summary, or a short ``{"outcome": ...}`` record for
     the two cases that stop before the scheduler lease is even acquired —
     a build that is not reactively scheduled, and one owned by another app.
+
+    Named for the function it *is* the body of, not for the engine
+    entry point it calls: ``run_tick_aio`` below is
+    :func:`stardag.build.run_tick_aio`, the executor-agnostic scheduler
+    pass, and this is the Modal-specific preamble around it.
+
+    **A coroutine, awaited by the deployed wrapper rather than driven by
+    ``asyncio.run``.** Ticks share a container (``_TICK_CONCURRENCY``), and
+    what makes that safe is that they share the container's *event loop*
+    and therefore the process-wide ``APIRegistry``'s one async client. So
+    everything below runs on the caller's loop, and every blocking call on
+    the way — the pre-lease registry read, the foreign-app forward, the
+    task-module import — is either awaited or deliberately accounted for:
+    on a shared container, a blocking call is not this tick's own latency,
+    it is a stall for every tick beside it.
     """
     _setup_logging()
     app_name = deployment.app_name
@@ -290,7 +306,7 @@ def _run_tick(
     # only on a genuine missing route; a resource-level 404 (build
     # deleted) must propagate as a real not-found.
     try:
-        build_info = registry.build_get(build_uuid)
+        build_info = await registry.build_get_aio(build_uuid)
     except NotFoundError as e:
         if not is_missing_route_error(e):
             raise
@@ -327,7 +343,10 @@ def _run_tick(
     if owner_app != app_name:
         forwarded = False
         try:
-            _spawn_tick(build_uuid, owner_app)
+            # Blocking backend call (a Modal RPC, hydrating a cold client),
+            # so off the loop: on a shared container it would stall every
+            # other tick. Same reasoning as ``drain_wake_candidates``.
+            await asyncio.to_thread(_spawn_tick, build_uuid, owner_app)
             forwarded = True
         except Exception as e:
             # Owner app deleted/renamed: the build is orphaned —
@@ -378,6 +397,16 @@ def _run_tick(
     # later "could not rehydrate" error can name them.
     if deployment.task_modules:
         set_declared_task_module_patterns(deployment.task_module_patterns)
+        # Stays ON the loop, unlike the forward above, and that is a
+        # deliberate trade. It is the one unbounded piece of work here — it
+        # can pull in a whole ML stack — so the first tick into a fresh
+        # container does stall any tick beside it. But this imports
+        # *arbitrary user modules*, and import-time side effects are
+        # routinely main-thread-only (``signal.signal`` raises outright off
+        # it), so running them in a worker thread trades a one-off,
+        # once-per-container stall for a class of failure that would
+        # surface as an unexplained import error in production. The
+        # per-module-list cache means later ticks return immediately.
         import_task_modules(deployment.task_modules)
 
     executor = ModalTaskExecutor(
@@ -387,16 +416,24 @@ def _run_tick(
         modal_workspace=deployment.modal_workspace,
         worker_timeouts=deployment.worker_timeouts,
     )
-    summary = asyncio.run(
-        run_tick_aio(
-            build_uuid,
-            registry=registry,
-            task_executor=executor,
-            task_store=task_store,
-            config=config,
-        )
+    summary = await run_tick_aio(
+        build_uuid,
+        registry=registry,
+        task_executor=executor,
+        task_store=task_store,
+        config=config,
     )
-    logger.info(f"Tick for build {build_id}: {summary}")
+    # The container id is in the line because ticks now share containers
+    # (``_TICK_CONCURRENCY``), and "how well are they packing?" is otherwise
+    # unanswerable from logs: ``modal app logs`` interleaves every function
+    # of the app with no per-container attribution, and ``modal container
+    # list`` names the app but not the function. Grouping this one line by
+    # container answers it, and it is also what tells you which container
+    # to reach for when one tick of many is misbehaving.
+    logger.info(
+        f"Tick for build {build_id} (container "
+        f"{os.environ.get('MODAL_TASK_ID', 'unknown')}): {summary}"
+    )
     return dataclasses.asdict(summary)
 
 

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -68,6 +68,26 @@ logger = logging.getLogger(__name__)
 _notify_read_route_missing = False
 
 
+# Connection-pool limits for the async client. Sized for a *process*, not
+# for one caller, which is the thing that changed: the client is cached per
+# event loop on a registry that is itself a process-wide singleton, so
+# whatever shares a loop shares this pool. A Modal container now serves up
+# to ``_TICK_CONCURRENCY`` scheduler ticks on one loop, each of which may
+# have ``TickConfig.max_concurrent_actions`` registry calls in flight.
+#
+# The old values — 10 and 5 — were a per-tick budget by accident, because a
+# tick used to own its container. Leaving them would have quietly divided
+# that budget by the number of co-resident ticks, i.e. turned a packing win
+# into a latency regression on wide frontiers. These restore roughly the
+# per-tick concurrency a tick had when it ran alone.
+#
+# ``keepalive_expiry`` is deliberately left where it was; it guards against
+# connections going stale behind a load balancer, and that has nothing to
+# do with how many callers share the pool.
+_ASYNC_MAX_CONNECTIONS = 100
+_ASYNC_MAX_KEEPALIVE_CONNECTIONS = 50
+
+
 def _latch_notify_read_missing(error: Exception) -> bool:
     """Whether ``error`` says the server predates ``GET .../notify``.
 
@@ -1135,8 +1155,8 @@ class APIRegistry(RegistryABC):
             # Use limits to prevent stale connection issues
             # keepalive_expiry=5 closes idle connections after 5 seconds
             limits = httpx.Limits(
-                max_connections=10,
-                max_keepalive_connections=5,
+                max_connections=_ASYNC_MAX_CONNECTIONS,
+                max_keepalive_connections=_ASYNC_MAX_KEEPALIVE_CONNECTIONS,
                 keepalive_expiry=5,
             )
             transport = RetryTransport(retry=_RETRY_CONFIG)

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -260,7 +260,7 @@ class TestUserVolumesOverride:
             ),
             extra_secrets=[],
             auto_volumes=result.auto_volumes,
-        )
+        ).kwargs
         # User volume should override auto volume at the same path
         assert settings["volumes"][EXPECTED_MOUNT_PATH] is user_volume
 
@@ -284,7 +284,7 @@ class TestUserVolumesOverride:
             FunctionSettings(image=TEST_IMAGE),
             extra_secrets=[],
             auto_volumes=result.auto_volumes,
-        )
+        ).kwargs
         assert EXPECTED_MOUNT_PATH in settings["volumes"]
 
 

--- a/lib/stardag/tests/test_integration/test_modal/test__settings.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__settings.py
@@ -21,6 +21,7 @@ except ImportError:
 from unittest.mock import MagicMock  # noqa: E402
 
 from stardag.integration.modal import FunctionSettings  # noqa: E402
+from stardag.exceptions import StardagError  # noqa: E402
 from stardag.integration.modal._settings import (  # noqa: E402
     _RENAMED_SETTINGS,
     _prepare_function_settings,
@@ -127,10 +128,27 @@ class TestInputConcurrencyIsLiftedOutOfTheKwargs:
             )
         ) == {"max_inputs": 8, "target_inputs": 6}
 
-    def test_a_target_alone_is_honoured(self):
-        assert _concurrency(
-            FunctionSettings(image=MagicMock(), target_concurrent_inputs=6)
-        ) == {"target_inputs": 6}
+    def test_a_target_alone_is_refused(self):
+        """Modal requires ``max_inputs`` whenever the decorator is applied,
+        and refuses at *registration* with a ``TypeError`` naming a
+        parameter the user never wrote. Caught here instead, in the names
+        they did write — and not papered over by merging stardag's own
+        tick default underneath, which would invent a ceiling nobody asked
+        for and could still be below the target."""
+        with pytest.raises(StardagError, match="without max_concurrent_inputs"):
+            _concurrency(
+                FunctionSettings(image=MagicMock(), target_concurrent_inputs=6)
+            )
+
+    def test_a_target_above_the_max_is_refused(self):
+        with pytest.raises(StardagError, match="above max_concurrent_inputs"):
+            _concurrency(
+                FunctionSettings(
+                    image=MagicMock(),
+                    max_concurrent_inputs=4,
+                    target_concurrent_inputs=6,
+                )
+            )
 
     def test_no_declaration_is_none_rather_than_a_concurrency_of_one(self):
         """``@modal.concurrent`` changes how a container serves inputs at
@@ -161,3 +179,56 @@ class TestSecretsAndVolumesStillMerge:
             "/mnt/x": user_volume,
             "/mnt/y": auto_volume,
         }
+
+
+class TestModalAcceptsWhatWeProduce:
+    """Every concurrency dict this module can emit, through the real Modal.
+
+    The app-level tests stub ``modal.concurrent`` out with a recording
+    identity decorator so they can invoke the wrappers, which means nothing
+    over there ever reaches Modal's own validation — and a declaration that
+    fails only at registration would sail through the whole suite and break
+    a deploy. So the shapes are checked against the real client here, the
+    same way the legacy-name premise is.
+    """
+
+    @pytest.mark.parametrize(
+        "settings",
+        [
+            FunctionSettings(image=MagicMock(), max_concurrent_inputs=10),
+            FunctionSettings(
+                image=MagicMock(),
+                max_concurrent_inputs=10,
+                target_concurrent_inputs=8,
+            ),
+            FunctionSettings(image=MagicMock(), allow_concurrent_inputs=3),
+        ],
+    )
+    def test_the_declaration_registers(self, settings):
+        concurrency = _concurrency(settings)
+        assert concurrency is not None
+
+        app = modal.App("settings-roundtrip")
+
+        async def body(x):
+            return x
+
+        # Decorator order matters and this is the order ``register`` uses:
+        # ``@app.function()`` on the outside, ``@modal.concurrent`` under
+        # it. The reverse raises ``InvalidError``.
+        app.function(image=modal.Image.debian_slim(), serialized=True, name="f")(
+            modal.concurrent(**concurrency)(body)
+        )
+
+    def test_the_stardag_tick_default_registers(self):
+        """The one concurrency stardag applies on its own initiative."""
+        from stardag.integration.modal._app import _TICK_CONCURRENCY
+
+        app = modal.App("settings-roundtrip-default")
+
+        async def body(x):
+            return x
+
+        app.function(image=modal.Image.debian_slim(), serialized=True, name="tick")(
+            modal.concurrent(**_TICK_CONCURRENCY)(body)
+        )

--- a/lib/stardag/tests/test_integration/test_modal/test__settings.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__settings.py
@@ -10,13 +10,18 @@ translation problem, and this is where the translation is pinned.
 from __future__ import annotations
 
 import typing
-from unittest.mock import MagicMock
 
-import modal
 import pytest
 
-from stardag.integration.modal import FunctionSettings
-from stardag.integration.modal._settings import (
+try:
+    import modal
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from stardag.integration.modal import FunctionSettings  # noqa: E402
+from stardag.integration.modal._settings import (  # noqa: E402
     _RENAMED_SETTINGS,
     _prepare_function_settings,
 )

--- a/lib/stardag/tests/test_integration/test_modal/test__settings.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__settings.py
@@ -1,0 +1,158 @@
+"""Unit tests for :mod:`stardag.integration.modal._settings`.
+
+The module exists because ``FunctionSettings`` is *not* a pass-through to
+``modal.App.function()``: Modal renamed three container-scaling parameters
+and moved input concurrency into a decorator, and its client raises on the
+old spellings rather than warning. So a settings dict is a small
+translation problem, and this is where the translation is pinned.
+"""
+
+from __future__ import annotations
+
+import typing
+from unittest.mock import MagicMock
+
+import modal
+import pytest
+
+from stardag.integration.modal import FunctionSettings
+from stardag.integration.modal._settings import (
+    _RENAMED_SETTINGS,
+    _prepare_function_settings,
+)
+
+
+def _prepare(settings) -> dict:
+    """The ``modal.App.function()`` kwargs half of the prepared result."""
+    return _prepare_function_settings(
+        settings, extra_secrets=[], auto_volumes={}
+    ).kwargs
+
+
+def _concurrency(settings):
+    """The ``modal.concurrent`` half."""
+    return _prepare_function_settings(
+        settings, extra_secrets=[], auto_volumes={}
+    ).concurrency
+
+
+class TestLegacyNamesAreTranslated:
+    """Every legacy name Modal rejects is accepted here and rewritten.
+
+    Not a nicety: each of these raises ``DeprecationError`` from
+    ``modal.App.function()``, so an app that sets one does not deploy at
+    all. Nobody can be relying on the current behaviour, which is what
+    makes translating rather than rejecting the right call.
+    """
+
+    @pytest.mark.parametrize(("legacy", "current"), sorted(_RENAMED_SETTINGS.items()))
+    def test_each_legacy_name_is_rewritten(self, legacy, current, caplog):
+        # Built as a plain dict rather than a TypedDict literal: the key is
+        # parametrized, which no literal can express — and a legacy name is
+        # something copied out of an older Modal doc anyway.
+        settings = typing.cast(FunctionSettings, {"image": MagicMock(), legacy: 4})
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._settings"):
+            prepared = _prepare(settings)
+
+        concurrency = _concurrency(settings)
+        # Concurrency settings leave via the decorator, the rest via kwargs.
+        if current in ("max_concurrent_inputs", "target_concurrent_inputs"):
+            assert concurrency == {"max_inputs": 4}
+            assert current not in prepared
+        else:
+            assert prepared[current] == 4
+        assert legacy not in prepared
+        assert "renamed" in caplog.text
+
+    @pytest.mark.parametrize("legacy", sorted(_RENAMED_SETTINGS))
+    def test_modal_itself_still_rejects_the_legacy_name(self, legacy):
+        """The premise, asserted rather than assumed.
+
+        If a future Modal client accepted these again, translating them
+        would become optional and this module could shrink — so the test
+        that would fail first belongs here.
+        """
+        app = modal.App("settings-premise")
+        kwargs: dict[str, typing.Any] = {"image": modal.Image.debian_slim(), legacy: 2}
+        with pytest.raises(Exception, match="deprecated|renamed|Deprecated"):
+            app.function(**kwargs)(lambda: None)
+
+    def test_the_current_name_wins_when_both_are_given(self, caplog):
+        """Resolving by dict order would be a rule nobody should have to
+        know; the explicit, current spelling is the intentional one."""
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._settings"):
+            prepared = _prepare(
+                FunctionSettings(
+                    image=MagicMock(), concurrency_limit=2, max_containers=9
+                )
+            )
+
+        assert prepared["max_containers"] == 9
+        assert "ignoring" in caplog.text
+
+    def test_a_declaration_using_only_current_names_is_left_alone(self, caplog):
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._settings"):
+            prepared = _prepare(
+                FunctionSettings(
+                    image=MagicMock(), max_containers=9, scaledown_window=30
+                )
+            )
+
+        assert prepared["max_containers"] == 9
+        assert prepared["scaledown_window"] == 30
+        assert caplog.text == ""
+
+
+class TestInputConcurrencyIsLiftedOutOfTheKwargs:
+    """``max_concurrent_inputs`` is a decorator, not a ``function()`` kwarg."""
+
+    def test_it_is_removed_from_the_function_kwargs(self):
+        prepared = _prepare(
+            FunctionSettings(
+                image=MagicMock(), max_concurrent_inputs=8, target_concurrent_inputs=6
+            )
+        )
+        assert "max_concurrent_inputs" not in prepared
+        assert "target_concurrent_inputs" not in prepared
+
+    def test_it_is_returned_under_modals_own_argument_names(self):
+        assert _concurrency(
+            FunctionSettings(
+                image=MagicMock(), max_concurrent_inputs=8, target_concurrent_inputs=6
+            )
+        ) == {"max_inputs": 8, "target_inputs": 6}
+
+    def test_a_target_alone_is_honoured(self):
+        assert _concurrency(
+            FunctionSettings(image=MagicMock(), target_concurrent_inputs=6)
+        ) == {"target_inputs": 6}
+
+    def test_no_declaration_is_none_rather_than_a_concurrency_of_one(self):
+        """``@modal.concurrent`` changes how a container serves inputs at
+        all, so a function that never asked for it must not be wrapped."""
+        assert _concurrency(FunctionSettings(image=MagicMock())) is None
+
+
+class TestSecretsAndVolumesStillMerge:
+    """The behaviour that was here before the translation layer."""
+
+    def test_secrets_are_deduped_by_name(self):
+        secret = modal.Secret.from_name("shared")
+        prepared = _prepare_function_settings(
+            FunctionSettings(image=MagicMock(), secrets=[secret]),
+            extra_secrets=[modal.Secret.from_name("shared")],
+            auto_volumes={},
+        )
+        assert len(prepared.kwargs["secrets"]) == 1
+
+    def test_user_volumes_win_over_auto_mounted_ones(self):
+        user_volume, auto_volume = MagicMock(), MagicMock()
+        prepared = _prepare_function_settings(
+            FunctionSettings(image=MagicMock(), volumes={"/mnt/x": user_volume}),
+            extra_secrets=[],
+            auto_volumes={"/mnt/x": auto_volume, "/mnt/y": auto_volume},
+        )
+        assert prepared.kwargs["volumes"] == {
+            "/mnt/x": user_volume,
+            "/mnt/y": auto_volume,
+        }

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -3307,18 +3307,21 @@ class TestInputConcurrency:
         )
         assert concurrency["tick"] == {"max_inputs": 32, "target_inputs": 24}
 
-    def test_the_default_is_not_merged_into_a_partial_override(self):
-        """An app that says only ``target_concurrent_inputs`` means it —
-        merging stardag's ``max_inputs`` underneath would silently cap a
-        deliberate declaration."""
-        concurrency = self._concurrency(
-            self._app(
-                tick_settings=FunctionSettings(
-                    image=_make_image(), target_concurrent_inputs=4
+    def test_a_target_without_a_max_fails_the_deploy_here(self):
+        """Not by merging stardag's own ceiling underneath — that would
+        invent a limit nobody asked for, and could still sit below the
+        target. Modal refuses the function either way; this refuses it
+        first, in the setting names the app actually wrote."""
+        from stardag.exceptions import StardagError
+
+        with pytest.raises(StardagError, match="without max_concurrent_inputs"):
+            self._concurrency(
+                self._app(
+                    tick_settings=FunctionSettings(
+                        image=_make_image(), target_concurrent_inputs=4
+                    )
                 )
             )
-        )
-        assert concurrency["tick"] == {"target_inputs": 4}
 
     def test_the_legacy_spelling_also_overrides_it(self):
         """``allow_concurrent_inputs`` is the name someone would reach for
@@ -3331,6 +3334,24 @@ class TestInputConcurrency:
             )
         )
         assert concurrency["tick"] == {"max_inputs": 3}
+
+    def test_a_packed_tick_does_not_drag_the_watchdog_with_it(self):
+        """``tick`` and ``tick_watchdog`` are registered from one
+        ``tick_settings``, so "no default for the watchdog" is not enough —
+        a declared value would reach it too. The watchdog is sync, so that
+        is Modal's *threaded* concurrency, which is the whole hazard the
+        tick is a coroutine to avoid; and Modal accepts a sync ``def`` with
+        ``@modal.concurrent`` and a ``schedule`` without complaint, so
+        nothing downstream would catch it."""
+        concurrency = self._concurrency(
+            self._app(
+                tick_settings=FunctionSettings(
+                    image=_make_image(), max_concurrent_inputs=32
+                )
+            )
+        )
+        assert concurrency["tick"] == {"max_inputs": 32}
+        assert concurrency["tick_watchdog"] is None
 
     def test_a_worker_may_opt_in_explicitly(self):
         """Stardag has no opinion for workers; an app that knows its own

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1537,8 +1537,16 @@ class TestFinalizeBakesTaskModules:
         _, _, captured = self._finalize(task_modules=[])
         build_id = uuid4()
         registry = MagicMock(spec=RegistryABC)
-        registry.build_get.return_value = BuildInfo(
-            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        # `build_get_aio`, not `build_get` — and it has to be stubbed
+        # explicitly. `MagicMock(spec=...)` auto-specs an async member as an
+        # AsyncMock, so leaving it alone does not raise: it returns a mock
+        # whose `reactive_app_name` is a mock, the tick decides the build
+        # belongs to another app, and the assertion below then passes
+        # because the tick never got as far as importing anything.
+        registry.build_get_aio = AsyncMock(
+            return_value=BuildInfo(
+                id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+            )
         )
 
         async def stub_tick_aio(build_uuid, **kwargs):
@@ -1871,9 +1879,12 @@ class TestReactivePickleElision:
         )
         registered = _finalize_capturing_functions(app)
 
-        with patch("stardag.integration.modal._app._run_tick") as run_tick:
+        with patch(
+            "stardag.integration.modal._app._run_deployed_tick_aio",
+            new_callable=AsyncMock,
+        ) as run_tick:
             run_tick.return_value = {}
-            registered["tick"](str(uuid4()), None)
+            _invoke(registered["tick"], str(uuid4()), None)
 
         assert run_tick.call_args.kwargs["deployment"].require_pickle_free is True
 
@@ -1885,9 +1896,12 @@ class TestReactivePickleElision:
         )
         registered = _finalize_capturing_functions(app)
 
-        with patch("stardag.integration.modal._app._run_tick") as run_tick:
+        with patch(
+            "stardag.integration.modal._app._run_deployed_tick_aio",
+            new_callable=AsyncMock,
+        ) as run_tick:
             run_tick.return_value = {}
-            registered["tick"](str(uuid4()), None)
+            _invoke(registered["tick"], str(uuid4()), None)
 
         assert run_tick.call_args.kwargs["deployment"].require_pickle_free is False
 
@@ -1914,10 +1928,12 @@ class TestTickTaskStoreIsPickleFree:
             require_pickle_free=require_pickle_free,
         )
         registry = MagicMock(spec=RegistryABC)
-        # Not reactively scheduled: _run_tick returns before it schedules
-        # anything, but only AFTER constructing the store — which is all
-        # this asserts on.
-        registry.build_get.return_value = MagicMock(reactive_app_name=None)
+        # Not reactively scheduled: the tick body returns before it
+        # schedules anything, but only AFTER constructing the store —
+        # which is all this asserts on.
+        registry.build_get_aio = AsyncMock(
+            return_value=MagicMock(reactive_app_name=None)
+        )
         stores: list = []
         real_store = tick_module.BuildTaskStore
 
@@ -1928,7 +1944,11 @@ class TestTickTaskStoreIsPickleFree:
 
         with patch.object(tick_module, "BuildTaskStore", capture):
             with registry_provider.override(registry):
-                tick_module._run_tick(str(uuid4()), None, deployment=deployment)
+                asyncio.run(
+                    tick_module._run_deployed_tick_aio(
+                        str(uuid4()), None, deployment=deployment
+                    )
+                )
         assert len(stores) == 1
         return stores[0]
 
@@ -3375,6 +3395,9 @@ class TestConcurrentTicksInOneContainer:
 
         tick = self._tick_wrapper()
         build_ids = [uuid4(), uuid4()]
+        # `asyncio.Barrier` is 3.11+, which the engine already requires
+        # (`_reactive/_discovery.py` uses `asyncio.TaskGroup` and
+        # `BaseExceptionGroup`) — CI runs 3.11-3.14.
         barrier = asyncio.Barrier(len(build_ids))
         driven: list[str] = []
 

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1,7 +1,9 @@
 """Tests for StardagApp build_function and run_function customization."""
 
+import asyncio
 import contextlib
 import importlib.util
+import inspect
 import io
 import pickletools
 import sys
@@ -16,7 +18,7 @@ try:
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from uuid import uuid4
 
 import stardag as _sd
@@ -44,6 +46,51 @@ from stardag.registry import NoOpRegistry, RegistryABC, registry_provider
 
 def _make_image() -> modal.Image:
     return modal.Image.debian_slim()
+
+
+# What ``@modal.concurrent`` was asked for, keyed by the callable it was
+# applied to. Populated by the autouse stub below and read by
+# ``TestInputConcurrency``; cleared per test.
+_CONCURRENCY_REQUESTS: dict[typing.Callable, dict[str, int]] = {}
+
+
+@pytest.fixture(autouse=True)
+def _stub_modal_concurrent():
+    """Replace ``modal.concurrent`` with a recording identity decorator.
+
+    The real decorator returns an opaque ``PartialFunction`` whose raw
+    callable is only reachable through Modal's synchronicity internals, and
+    every test in this file wants to *invoke* the registered wrapper. So the
+    decorator is stubbed out: the wrappers stay plain functions, and what
+    stardag asked Modal for is recorded instead. That request is the part
+    worth pinning here anyway — how Modal implements input concurrency is
+    Modal's business, and asserting it would pin their internals.
+    """
+
+    def concurrent(**kwargs):
+        def decorator(fn):
+            _CONCURRENCY_REQUESTS[fn] = kwargs
+            return fn
+
+        return decorator
+
+    _CONCURRENCY_REQUESTS.clear()
+    with patch("modal.concurrent", concurrent):
+        yield
+    _CONCURRENCY_REQUESTS.clear()
+
+
+def _invoke(fn, *args, **kwargs):
+    """Call a registered wrapper, driving it to completion if it is async.
+
+    The deployed ``tick`` is an ``async def`` so that concurrent inputs
+    share one event loop and therefore one registry client; every other
+    wrapper is sync. Tests call both through here rather than caring.
+    """
+    result = fn(*args, **kwargs)
+    if inspect.iscoroutine(result):
+        return asyncio.run(result)
+    return result
 
 
 def _finalize_capturing_functions(app: StardagApp) -> dict:
@@ -1457,8 +1504,10 @@ class TestFinalizeBakesTaskModules:
         _, result, captured = self._finalize(task_modules=["stardag.utils.*"])
         build_id = uuid4()
         registry = MagicMock(spec=RegistryABC)
-        registry.build_get.return_value = BuildInfo(
-            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        registry.build_get_aio = AsyncMock(
+            return_value=BuildInfo(
+                id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+            )
         )
 
         async def stub_tick_aio(build_uuid, **kwargs):
@@ -1472,7 +1521,7 @@ class TestFinalizeBakesTaskModules:
             ) as import_modules,
         ):
             rp.get.return_value = registry
-            captured["tick"](str(build_id))
+            _invoke(captured["tick"], str(build_id))
 
         # Exactly the list frozen at deploy time — not re-derived in the
         # container, where the filesystem walk would cost cold-start time.
@@ -1503,7 +1552,7 @@ class TestFinalizeBakesTaskModules:
             ) as import_modules,
         ):
             rp.get.return_value = registry
-            captured["tick"](str(build_id))
+            _invoke(captured["tick"], str(build_id))
 
         import_modules.assert_not_called()
 
@@ -2260,15 +2309,17 @@ class TestDeployedFunctionsAreSerializable:
 
         build_id = uuid4()
         registry = MagicMock(spec=RegistryABC)
-        registry.build_get.return_value = BuildInfo(
-            id=build_id, reactive_app_name="another-app", reactive_tick_kwargs=None
+        registry.build_get_aio = AsyncMock(
+            return_value=BuildInfo(
+                id=build_id, reactive_app_name="another-app", reactive_tick_kwargs=None
+            )
         )
         with (
             patch("stardag.integration.modal._tick.registry_provider") as rp,
             patch("modal.Function.from_name", side_effect=Exception("no such app")),
         ):
             rp.get.return_value = registry
-            result = tick(str(build_id))
+            result = _invoke(tick, str(build_id))
 
         # It compared the build's owner against the app name it was
         # deployed with, which means that capture survived the round trip.
@@ -2281,7 +2332,7 @@ class TestDeployedFunctionsAreSerializable:
 
 class TestTickAppOwnership:
     """Only the app recorded as the build's reactive_app_name (in the
-    registry) may drive its ticks — read via the lighter build_get."""
+    registry) may drive its ticks — read via the lighter build_get_aio."""
 
     def _capture_tick(self, app_name: str):
         app = StardagApp(
@@ -2306,17 +2357,19 @@ class TestTickAppOwnership:
 
     @staticmethod
     def _registry_with_reactive_app(build_id, reactive_app_name, tick_kwargs=None):
-        """A registry whose build_get returns the given reactive marker.
+        """A registry whose build_get_aio returns the given reactive marker.
 
         ``reactive_app_name=None`` models a non-reactive build.
         """
         from stardag.registry import BuildInfo
 
         registry = MagicMock(spec=RegistryABC)
-        registry.build_get.return_value = BuildInfo(
-            id=build_id,
-            reactive_app_name=reactive_app_name,
-            reactive_tick_kwargs=tick_kwargs,
+        registry.build_get_aio = AsyncMock(
+            return_value=BuildInfo(
+                id=build_id,
+                reactive_app_name=reactive_app_name,
+                reactive_tick_kwargs=tick_kwargs,
+            )
         )
         return registry
 
@@ -2347,7 +2400,7 @@ class TestTickAppOwnership:
             patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
         ):
             rp.get.return_value = registry
-            tick(str(build_id))
+            _invoke(tick, str(build_id))
 
         config = captured_config["config"]
         assert config.spawn_tick is not None
@@ -2384,7 +2437,7 @@ class TestTickAppOwnership:
             patch("stardag.integration.modal._tick.run_tick_aio") as tick_aio,
         ):
             rp.get.return_value = registry
-            result = tick(str(build_id))
+            result = _invoke(tick, str(build_id))
 
         assert result == {
             "outcome": "foreign_app",
@@ -2417,7 +2470,7 @@ class TestTickAppOwnership:
             ),
         ):
             rp.get.return_value = registry
-            result = tick(str(build_id))
+            result = _invoke(tick, str(build_id))
 
         assert result == {
             "outcome": "foreign_app",
@@ -2440,7 +2493,7 @@ class TestTickAppOwnership:
             patch("stardag.integration.modal._tick.run_tick_aio") as tick_aio,
         ):
             rp.get.return_value = registry
-            result = tick(str(build_id))
+            result = _invoke(tick, str(build_id))
 
         assert result == {"outcome": "not_reactive"}
         tick_aio.assert_not_called()
@@ -2469,7 +2522,7 @@ class TestTickAppOwnership:
             patch("stardag.integration.modal._tick.registry_provider") as rp,
         ):
             rp.get.return_value = own_registry
-            assert tick(str(own))["outcome"] == "noop"
+            assert _invoke(tick, str(own))["outcome"] == "noop"
         assert ticked == [str(own)]
 
 
@@ -2880,7 +2933,10 @@ class TestContainerSetup:
         """Stub out what the wrappers delegate to, leaving only the hook."""
         with contextlib.ExitStack() as stack:
             tick = stack.enter_context(
-                patch("stardag.integration.modal._app._run_tick")
+                patch(
+                    "stardag.integration.modal._app._run_deployed_tick_aio",
+                    new_callable=AsyncMock,
+                )
             )
             bootstrap = stack.enter_context(
                 patch("stardag.integration.modal._app.run_reactive_bootstrap")
@@ -2897,7 +2953,7 @@ class TestContainerSetup:
         "build": lambda fn: fn("task", "selector", "test-app", None),
         "worker_default": lambda fn: fn("task"),
         "worker_gpu": lambda fn: fn("task"),
-        "tick": lambda fn: fn(str(uuid4()), None),
+        "tick": lambda fn: _invoke(fn, str(uuid4()), None),
         "bootstrap": lambda fn: fn(str(uuid4()), [], None),
         "tick_watchdog": lambda fn: fn(),
     }
@@ -2927,7 +2983,7 @@ class TestContainerSetup:
             registered["worker_default"]("task")
             registered["worker_gpu"]("task")
             registered["build"]("task", "selector", "test-app", None)
-            registered["tick"](str(uuid4()), None)
+            _invoke(registered["tick"], str(uuid4()), None)
 
         assert calls == ["setup"]
 
@@ -3004,7 +3060,7 @@ class TestContainerSetup:
 
         registered = _finalize_capturing_functions(app)
         with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
-            registered["tick"](str(uuid4()), None)
+            _invoke(registered["tick"], str(uuid4()), None)
 
         # Nothing recorded, so nothing was run and nothing is retained.
         assert _container_setup_module._setup_done == []
@@ -3020,7 +3076,7 @@ class TestContainerSetup:
 
         Everything the feature claims rests on this: the hook has to
         precede the wrapper's own body, which is what puts it ahead of
-        ``Builder.setup`` / ``Runner.setup`` / ``_run_tick`` and therefore
+        ``Builder.setup`` / ``Runner.setup`` / the tick body, and therefore
         ahead of stardag's ``logging.basicConfig`` default. Asserting only
         that the hook ran would pass with the call moved to the bottom of
         every wrapper.
@@ -3047,7 +3103,10 @@ class TestContainerSetup:
 
         with contextlib.ExitStack() as stack:
             tick = stack.enter_context(
-                patch("stardag.integration.modal._app._run_tick")
+                patch(
+                    "stardag.integration.modal._app._run_deployed_tick_aio",
+                    new_callable=AsyncMock,
+                )
             )
             bootstrap = stack.enter_context(
                 patch("stardag.integration.modal._app.run_reactive_bootstrap")
@@ -3086,7 +3145,10 @@ class TestContainerSetup:
 
         with contextlib.ExitStack() as stack:
             tick = stack.enter_context(
-                patch("stardag.integration.modal._app._run_tick")
+                patch(
+                    "stardag.integration.modal._app._run_deployed_tick_aio",
+                    new_callable=AsyncMock,
+                )
             )
             sweep = stack.enter_context(
                 patch("stardag.integration.modal._app._run_watchdog_sweep")
@@ -3142,6 +3204,300 @@ class TestContainerSetup:
         otherwise deploy cleanly and raise in every container."""
         with pytest.raises(TypeError, match="no arguments"):
             self._app(lambda config: None)  # type: ignore[arg-type,misc]
+
+
+class TestInputConcurrency:
+    """Which deployed functions may serve several inputs per container.
+
+    The tick and nothing else. It is almost entirely I/O wait — read the
+    frontier, spawn, then poll on a sleep until its linger deadline — so a
+    container per tick is close to the worst packing available, and the
+    linger that makes reactive scheduling efficient is what keeps those
+    containers alive. Nothing else in the app has that shape.
+
+    The two halves are one decision: Modal serves concurrent inputs to an
+    ``async def`` as tasks on one event loop and to a ``def`` on threads,
+    and threaded ticks would thrash the process-wide registry's per-loop
+    HTTP client (see ``TestAsyncClientUnderConcurrentCallers`` in the
+    registry tests). So "async" and "concurrent" are asserted together.
+    """
+
+    @staticmethod
+    def _app(**app_kwargs) -> StardagApp:
+        return StardagApp(
+            "test-concurrency",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={
+                "default": FunctionSettings(image=_make_image()),
+                "gpu": FunctionSettings(image=_make_image()),
+            },
+            watchdog_period_minutes=5,
+            **app_kwargs,
+        )
+
+    def _concurrency(self, app) -> dict:
+        """What ``@modal.concurrent`` was asked for, by function name."""
+        registered = _finalize_capturing_functions(app)
+        return {name: _CONCURRENCY_REQUESTS.get(fn) for name, fn in registered.items()}
+
+    def test_the_deployed_tick_is_a_coroutine_function(self):
+        """Load-bearing, not a style choice: a sync tick would be served
+        on threads, each with its own ``asyncio.run`` and therefore its own
+        event loop, and the shared ``APIRegistry`` closes and rebuilds its
+        async client whenever the running loop changes."""
+        registered = _finalize_capturing_functions(self._app())
+        assert inspect.iscoroutinefunction(registered["tick"])
+
+    def test_every_other_registered_function_is_sync(self):
+        """The tick is the exception, and it should stay legible as one."""
+        registered = _finalize_capturing_functions(self._app())
+        assert [
+            name for name, fn in registered.items() if inspect.iscoroutinefunction(fn)
+        ] == ["tick"]
+
+    def test_the_tick_gets_a_default(self):
+        assert self._concurrency(self._app())["tick"] == {"max_inputs": 10}
+
+    def test_nothing_else_does(self):
+        """Workers run user code and may be CPU- or GPU-bound; the builder
+        runs a whole build; the bootstrap walks a DAG. And the watchdog —
+        which shares ``tick_settings`` — is a separate function with its own
+        containers that receives one input per period, so packing it would
+        change nothing while quietly opting a ``def`` into threading."""
+        concurrency = self._concurrency(self._app())
+        assert concurrency.pop("tick") is not None
+        assert set(concurrency) == {
+            "build",
+            "worker_default",
+            "worker_gpu",
+            "bootstrap",
+            "tick_watchdog",
+        }
+        assert all(value is None for value in concurrency.values())
+
+    def test_tick_settings_override_the_default(self):
+        concurrency = self._concurrency(
+            self._app(
+                tick_settings=FunctionSettings(
+                    image=_make_image(),
+                    max_concurrent_inputs=32,
+                    target_concurrent_inputs=24,
+                )
+            )
+        )
+        assert concurrency["tick"] == {"max_inputs": 32, "target_inputs": 24}
+
+    def test_the_default_is_not_merged_into_a_partial_override(self):
+        """An app that says only ``target_concurrent_inputs`` means it —
+        merging stardag's ``max_inputs`` underneath would silently cap a
+        deliberate declaration."""
+        concurrency = self._concurrency(
+            self._app(
+                tick_settings=FunctionSettings(
+                    image=_make_image(), target_concurrent_inputs=4
+                )
+            )
+        )
+        assert concurrency["tick"] == {"target_inputs": 4}
+
+    def test_the_legacy_spelling_also_overrides_it(self):
+        """``allow_concurrent_inputs`` is the name someone would reach for
+        from Modal's pre-1.0 docs, and it never worked here — it raised."""
+        concurrency = self._concurrency(
+            self._app(
+                tick_settings=FunctionSettings(
+                    image=_make_image(), allow_concurrent_inputs=3
+                )
+            )
+        )
+        assert concurrency["tick"] == {"max_inputs": 3}
+
+    def test_a_worker_may_opt_in_explicitly(self):
+        """Stardag has no opinion for workers; an app that knows its own
+        run function is I/O-bound is entitled to one."""
+        app = StardagApp(
+            "test-concurrency",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={
+                "default": FunctionSettings(
+                    image=_make_image(), max_concurrent_inputs=5
+                )
+            },
+        )
+        assert self._concurrency(app)["worker_default"] == {"max_inputs": 5}
+
+
+class TestConcurrentTicksInOneContainer:
+    """Two ticks genuinely overlapping in one process, which is the only
+    condition under which any of this is observable.
+
+    ``TestInputConcurrency`` pins that the tick is async and asks for
+    concurrency; this pins that two of them actually running at once stay
+    out of each other's way. Every hazard here is silent until it happens:
+    a shared registry singleton, a shared HTTP client, a ``ContextVar``
+    holding "the build this code is running for".
+    """
+
+    @staticmethod
+    def _tick_wrapper(app_name: str = "shared-container"):
+        app = StardagApp(
+            app_name,
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+        return _finalize_capturing_functions(app)["tick"]
+
+    @staticmethod
+    def _registry(app_name: str = "shared-container"):
+        from stardag.registry import BuildInfo
+
+        registry = MagicMock(spec=RegistryABC)
+
+        async def build_get_aio(build_id):
+            # A round trip, so the two ticks interleave here as well as in
+            # the body — the pre-lease read is the tick's first await.
+            await asyncio.sleep(0)
+            return BuildInfo(
+                id=build_id,
+                reactive_app_name=app_name,
+                reactive_tick_kwargs=None,
+            )
+
+        registry.build_get_aio = build_get_aio
+        return registry
+
+    def test_overlapping_ticks_each_drive_their_own_build(
+        self, default_in_memory_fs_target
+    ):
+        """The bodies are held at a barrier, so neither can finish before
+        the other has started: whatever they share, they share it live."""
+        from stardag.build import TickSummary
+
+        tick = self._tick_wrapper()
+        build_ids = [uuid4(), uuid4()]
+        barrier = asyncio.Barrier(len(build_ids))
+        driven: list[str] = []
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            await barrier.wait()
+            driven.append(str(build_uuid))
+            return TickSummary(outcome="lingered_out", iterations=1)
+
+        async def main():
+            return await asyncio.gather(
+                *(tick(str(build_id)) for build_id in build_ids)
+            )
+
+        with (
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+        ):
+            rp.get.return_value = self._registry()
+            summaries = asyncio.run(main())
+
+        assert sorted(driven) == sorted(str(b) for b in build_ids)
+        assert [summary["outcome"] for summary in summaries] == [
+            "lingered_out",
+            "lingered_out",
+        ]
+
+    def test_the_build_id_context_var_stays_per_tick(self, default_in_memory_fs_target):
+        """``current_build_id_var`` is how a task's registry calls learn
+        which build they belong to. Asyncio tasks copy context, so a set
+        inside one tick is invisible to the other — but only as long as
+        each input really is its own task, which is the assumption the
+        whole design rides on. Held at a barrier so the two sets are live
+        at the same moment.
+        """
+        from stardag.build import TickSummary
+        from stardag.build._base import current_build_id_var
+
+        tick = self._tick_wrapper()
+        build_ids = [uuid4(), uuid4()]
+        barrier = asyncio.Barrier(len(build_ids))
+        observed: dict[str, object] = {}
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            token = current_build_id_var.set(build_uuid)
+            try:
+                await barrier.wait()
+                observed[str(build_uuid)] = current_build_id_var.get()
+                return TickSummary(outcome="lingered_out")
+            finally:
+                current_build_id_var.reset(token)
+
+        async def main():
+            await asyncio.gather(*(tick(str(b)) for b in build_ids))
+
+        with (
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+        ):
+            rp.get.return_value = self._registry()
+            asyncio.run(main())
+
+        assert observed == {str(b): b for b in build_ids}
+        assert current_build_id_var.get() is None
+
+    def test_a_foreign_app_forward_does_not_block_the_other_tick(
+        self, default_in_memory_fs_target, modal_function_stub
+    ):
+        """The forward is a blocking Modal RPC. It has to leave the event
+        loop, or one tick that lands on the wrong app stalls every tick
+        beside it for the length of a backend round trip."""
+        tick = self._tick_wrapper("app-b")
+        forwarding_build, own_build = uuid4(), uuid4()
+        released = threading.Event()
+        progressed: list[str] = []
+        spawn_saw_progress: list[bool] = []
+
+        def slow_spawn(build_id, app_name, tick_kwargs=None):
+            # Blocks until the *other* tick has run. Off the loop that
+            # happens; on the loop nothing else can run while this call is
+            # on the stack, so the wait times out and the assertion below
+            # is what tells you the spawn went back inline.
+            spawn_saw_progress.append(released.wait(timeout=2))
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            from stardag.build import TickSummary
+
+            progressed.append(str(build_uuid))
+            released.set()
+            return TickSummary(outcome="lingered_out")
+
+        registry = MagicMock(spec=RegistryABC)
+
+        async def build_get_aio(build_id):
+            from stardag.registry import BuildInfo
+
+            return BuildInfo(
+                id=build_id,
+                reactive_app_name="app-a" if build_id == forwarding_build else "app-b",
+                reactive_tick_kwargs=None,
+            )
+
+        registry.build_get_aio = build_get_aio
+
+        async def main():
+            return await asyncio.gather(
+                tick(str(forwarding_build)), tick(str(own_build))
+            )
+
+        with (
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick._spawn_tick", slow_spawn),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+        ):
+            rp.get.return_value = registry
+            forwarded, own = asyncio.run(main())
+
+        assert forwarded["outcome"] == "foreign_app"
+        assert forwarded["forwarded"] is True
+        assert progressed == [str(own_build)]
+        assert spawn_saw_progress == [True], (
+            "the other tick made no progress while the forward's blocking "
+            "spawn was in flight — it is running on the event loop"
+        )
 
 
 class TestUnreachableWorkerWarning:

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -1483,3 +1483,108 @@ class TestSchedulerLeaseCalls:
         )
         assert new._scheduler_lease_route_missing is False
         assert result.held is False, "the other registry's latch leaked"
+
+
+class TestAsyncClientUnderConcurrentCallers:
+    """The invariant that lets scheduler ticks share a Modal container.
+
+    ``registry_provider`` hands out one process-wide ``APIRegistry``, and
+    its ``async_client`` is cached **per event loop**: a call from a
+    different loop rebuilds it and closes the previous one. That is fine
+    while one caller owns the process, and actively destructive once
+    several do — which is exactly what input concurrency introduces.
+
+    Modal decides the shape: an ``async def`` gets its concurrent inputs as
+    asyncio tasks on one loop, a ``def`` gets them on threads, each
+    running its own ``asyncio.run``. So "the deployed tick is async" and
+    "ticks may share a container" are one decision, and this class pins
+    both halves of it — the safe shape and the hazard it avoids — because
+    neither is visible until two ticks actually overlap.
+    """
+
+    @staticmethod
+    def _registry() -> APIRegistry:
+        return APIRegistry(api_url="http://test.invalid", api_key="test-key")
+
+    def test_concurrent_callers_on_one_loop_share_one_stable_client(self):
+        """The async tick's world: N ticks, one loop, one client.
+
+        Each "tick" reads the client, yields (as a real one does on every
+        await), and reads it again. All four reads must be the same object,
+        and it must still be open — a rebuild would have closed it under
+        whoever was mid-request.
+        """
+        import asyncio
+
+        registry = self._registry()
+
+        async def fake_tick() -> list[httpx.AsyncClient]:
+            first = registry.async_client
+            await asyncio.sleep(0)
+            return [first, registry.async_client]
+
+        async def main():
+            return await asyncio.gather(*(fake_tick() for _ in range(4)))
+
+        seen: list[list[httpx.AsyncClient]] = asyncio.run(main())
+
+        clients = {id(client) for reads in seen for client in reads}
+        assert len(clients) == 1, (
+            "ticks sharing a container must share one async client; a "
+            "rebuild closes the client another tick is using"
+        )
+        assert not next(iter(seen))[0].is_closed
+
+    def test_callers_on_separate_loops_rebuild_and_close_the_shared_client(
+        self,
+    ):
+        """The sync tick's world, and why the deployed tick is not that.
+
+        Threaded concurrency gives each input its own ``asyncio.run`` and
+        therefore its own loop, so the second caller's first property access
+        tears down the first caller's client mid-flight. Asserted rather
+        than merely described: if Modal or ``APIRegistry`` ever stopped
+        behaving this way, making the tick async would have stopped being
+        load-bearing, and that is worth being told about.
+        """
+        import asyncio
+        import threading
+
+        registry = self._registry()
+        clients: dict[str, httpx.AsyncClient] = {}
+        first_read = threading.Event()
+        b_done = threading.Event()
+
+        def caller_a():
+            async def body():
+                clients["a"] = registry.async_client
+                first_read.set()
+                # Wait for B to touch the property from its own loop.
+                await asyncio.get_running_loop().run_in_executor(None, b_done.wait, 5)
+                clients["a_again"] = registry.async_client
+
+            asyncio.run(body())
+
+        def caller_b():
+            async def body():
+                first_read.wait(5)
+                clients["b"] = registry.async_client
+
+            asyncio.run(body())
+            b_done.set()
+
+        thread_a = threading.Thread(target=caller_a)
+        thread_b = threading.Thread(target=caller_b)
+        thread_a.start()
+        thread_b.start()
+        thread_a.join(timeout=10)
+        thread_b.join(timeout=10)
+
+        assert clients["b"] is not clients["a"], (
+            "a second event loop rebuilds the cached client — this is the "
+            "thrash the deployed tick is async to avoid"
+        )
+        assert clients["a_again"] is not clients["a"], (
+            "and A's next read gets a third client, so the one it was "
+            "using mid-tick was replaced underneath it"
+        )

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -1594,3 +1594,10 @@ class TestAsyncClientUnderConcurrentCallers:
             "and A's next read gets a third client, so the one it was "
             "using mid-tick was replaced underneath it"
         )
+        # The destructive half, and the reason this is a bug rather than
+        # wasted allocation: the displaced client is closed, so a request
+        # already in flight on it fails.
+        assert clients["a"].is_closed, (
+            "the displaced client was left open — the hazard here is that "
+            "it is closed under a caller mid-request"
+        )

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -1555,34 +1555,43 @@ class TestAsyncClientUnderConcurrentCallers:
         first_read = threading.Event()
         b_done = threading.Event()
 
+        # The rendezvous waits are deliberately unbounded, and the threads
+        # daemons. A bounded wait would let a thread that never
+        # rendezvoused carry on into the reads below and fail one of the
+        # real assertions, which would then be describing a coordination
+        # failure in the language of a client-caching bug. Unbounded, a
+        # thread that cannot proceed simply does not finish, and the one
+        # bound that matters — `join(timeout=...)` plus `is_alive()` — says
+        # exactly that. `daemon=True` is what keeps such a thread from
+        # holding the interpreter open at exit.
         def caller_a():
             async def body():
                 clients["a"] = registry.async_client
                 first_read.set()
                 # Wait for B to touch the property from its own loop.
-                await asyncio.get_running_loop().run_in_executor(None, b_done.wait, 5)
+                await asyncio.get_running_loop().run_in_executor(None, b_done.wait)
                 clients["a_again"] = registry.async_client
 
             asyncio.run(body())
 
         def caller_b():
             async def body():
-                first_read.wait(5)
+                first_read.wait()
                 clients["b"] = registry.async_client
 
             asyncio.run(body())
             b_done.set()
 
-        thread_a = threading.Thread(target=caller_a)
-        thread_b = threading.Thread(target=caller_b)
+        thread_a = threading.Thread(target=caller_a, daemon=True)
+        thread_b = threading.Thread(target=caller_b, daemon=True)
         thread_a.start()
         thread_b.start()
         thread_a.join(timeout=10)
         thread_b.join(timeout=10)
 
-        # Before reading `clients`: a thread still alive means one of the
-        # waits above timed out, and every assertion below would then fail
-        # with a KeyError that says nothing about what actually went wrong.
+        # Before reading `clients`: a thread still alive means the two
+        # never rendezvoused, and every assertion below would otherwise
+        # fail with a KeyError that says nothing about what went wrong.
         assert not thread_a.is_alive() and not thread_b.is_alive(), (
             "a caller thread did not finish; the two never rendezvoused"
         )

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -1523,17 +1523,25 @@ class TestAsyncClientUnderConcurrentCallers:
             await asyncio.sleep(0)
             return [first, registry.async_client]
 
-        async def main():
-            return await asyncio.gather(*(fake_tick() for _ in range(4)))
+        async def main() -> None:
+            reads: list[list[httpx.AsyncClient]] = await asyncio.gather(
+                *(fake_tick() for _ in range(4))
+            )
 
-        seen: list[list[httpx.AsyncClient]] = asyncio.run(main())
+            clients = {id(client) for tick_reads in reads for client in tick_reads}
+            assert len(clients) == 1, (
+                "ticks sharing a container must share one async client; a "
+                "rebuild closes the client another tick is using"
+            )
+            assert not reads[0][0].is_closed
 
-        clients = {id(client) for reads in seen for client in reads}
-        assert len(clients) == 1, (
-            "ticks sharing a container must share one async client; a "
-            "rebuild closes the client another tick is using"
-        )
-        assert not next(iter(seen))[0].is_closed
+            # Asserted and closed inside the loop, not after it. An
+            # AsyncClient belongs to the loop it was built on and can only
+            # be closed from there, so a test that returns one and tidies
+            # up afterwards has no way to close it at all.
+            await registry.aclose()
+
+        asyncio.run(main())
 
     def test_callers_on_separate_loops_rebuild_and_close_the_shared_client(
         self,
@@ -1588,6 +1596,13 @@ class TestAsyncClientUnderConcurrentCallers:
         thread_b.start()
         thread_a.join(timeout=10)
         thread_b.join(timeout=10)
+
+        # The two survivors are deliberately left unclosed. Each belongs to
+        # a loop that has since ended, so there is nowhere to close them
+        # from — which is the hazard this test exists to describe, not an
+        # oversight in the test. Nothing leaks in practice: no request is
+        # ever issued here, so no connection is ever opened, and the suite
+        # is clean under `-W error::ResourceWarning`.
 
         # Before reading `clients`: a thread still alive means the two
         # never rendezvoused, and every assertion below would otherwise

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -1580,6 +1580,12 @@ class TestAsyncClientUnderConcurrentCallers:
         thread_a.join(timeout=10)
         thread_b.join(timeout=10)
 
+        # Before reading `clients`: a thread still alive means one of the
+        # waits above timed out, and every assertion below would then fail
+        # with a KeyError that says nothing about what actually went wrong.
+        assert not thread_a.is_alive() and not thread_b.is_alive(), (
+            "a caller thread did not finish; the two never rendezvoused"
+        )
         assert clients["b"] is not clients["a"], (
             "a second event loop rebuilds the cached client — this is the "
             "thrash the deployed tick is async to avoid"


### PR DESCRIPTION
A scheduler tick is almost entirely I/O wait: it reads the frontier,
spawns, then polls on a sleep until its linger deadline. One container per
tick was close to the worst available packing — and the linger that makes
reactive scheduling efficient, one resident scheduler driving level after
level instead of a cold start per level, is exactly what kept those
containers alive.

The deployed `tick` is now an `async def` registered with
`max_concurrent_inputs=10`, so one container serves up to ten concurrent
reactive builds.

## Why async is load-bearing, not stylistic

Modal serves concurrent inputs to a sync function on **threads**, each
running its own `asyncio.run` and therefore its own event loop.
`APIRegistry` is a process-wide singleton whose `async_client` is cached
per loop and *closed and rebuilt* whenever the running loop differs — so
two threaded ticks tear down each other's in-flight HTTP client:

```
A       -> client 4491730896 (loop A)
B       -> client 4491796048 (loop B)   # rebuilt; closed A's client
A-again -> client 4491800208            # a THIRD client
```

Awaiting the body keeps every tick in a container on one loop and
therefore on one client. `TestAsyncClientUnderConcurrentCallers` pins both
halves — the safe shape, and the hazard it avoids — because neither is
visible until two ticks actually overlap.

## What is packed, and what is not

Only the tick. Workers run user code and may be CPU- or GPU-bound; the
builder runs a whole build; the bootstrap walks a DAG.

Not `tick_watchdog` either, even though it shares `tick_settings`: it is
its own Modal function with its own containers and gets one input per
watchdog period, so packing changes nothing in the steady state — while
quietly opting a `def` into the threading above.

## `FunctionSettings` needed the vocabulary first

Modal renamed three container-scaling parameters in Feb 2025 and moved
input concurrency into `@modal.concurrent` in Apr 2025, and its client
**raises** on the old spellings rather than warning. `FunctionSettings`
declared all four and passed them straight through:

```
allow_concurrent_inputs -> DeprecationError ... Use the '@modal.concurrent' decorator instead
concurrency_limit       -> DeprecationError ... renamed to 'max_containers'
container_idle_timeout  -> DeprecationError ... renamed to 'scaledown_window'
keep_warm               -> DeprecationError ... renamed to 'min_containers'
```

So any app that set one of them failed to deploy — a bug fix, not a
deprecation, since no behaviour can depend on a raise. It now accepts
`max_containers`, `min_containers`, `buffer_containers`,
`scaledown_window`, `max_concurrent_inputs` and
`target_concurrent_inputs`, translates the four legacy names with a
warning, and returns the concurrency arguments beside the `function()`
kwargs as a `PreparedFunction` — so one declaration is read once and
applied whole rather than half-applied.

## Three supporting changes

Each was correct per-tick and wrong per-container:

- **The async client's pool.** `max_connections=10` was a per-tick budget
  only because a tick owned the process. Ten co-resident ticks would have
  divided it between them, turning a packing win into a latency regression
  on wide frontiers.
- **`_hand_off_if_needed`'s blocking spawn** ran inline, justified in a
  comment by "nothing else is in flight" — true of a tick, false of its
  container. Now `asyncio.to_thread`, like `drain_wake_candidates` already
  was.
- **`_load_task`'s task-store reads** are blocking target-root I/O called
  once per actionable task, up to `max_concurrent_actions` per pass.

The task-module import deliberately **stays** on the loop: it imports
arbitrary user modules, and import-time side effects are routinely
main-thread-only (`signal.signal` raises outright off it), so a worker
thread would trade a one-off, once-per-container stall for a class of
failure that surfaces as an unexplained import error in production.

## Verification

Both `to_thread` moves have a guard that was confirmed to **fail** when
the blocking call is put back on the loop, rather than merely to pass.

Live, on a real Modal stack with a real registry: five concurrent
reactive builds, each lingering 150s, all five ticks served by one
container —

```
ta-01M1D21NT7T08W74WBM33CZG5R  01a05a20-b006-…
ta-01M1D21NT7T08W74WBM33CZG5R  01a05a20-b7ac-…
ta-01M1D21NT7T08W74WBM33CZG5R  01a05a20-bd44-…
ta-01M1D21NT7T08W74WBM33CZG5R  01a05a20-c1d9-…
ta-01M1D21NT7T08W74WBM33CZG5R  01a05a20-c75e-…
```

— all five builds `completed`. The registry-live scenarios pass against
the same stack. The tick's completion log line now carries
`MODAL_TASK_ID`, which is what made that table readable: `modal app logs`
has no per-container attribution and `modal container list` names the app
but not the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
