### PR TITLE
Cover the remaining reactive behaviour in the registry-live tier

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -191,7 +191,31 @@ worker writes status, the registry flags wake candidates, and the worker
 spawns the next tick when no scheduler is live.
 
 `integration-tests/tests_registry_live/` covers it, by deploying a registry
-for the run.
+for the run. What the scenarios there assert:
+
+| Scenario                    | The question it answers                                                                 |
+| --------------------------- | --------------------------------------------------------------------------------------- |
+| `test_reactive_e2e`         | With nothing resident anywhere, does a worker spawn the next tick?                      |
+| `test_claim_race`           | Two builds want one task; does the registry let exactly one run it?                     |
+| `test_cross_build_wake`     | A blocker finishes in one build — is a different, dormant build woken?                  |
+| `test_wake_storm`           | Several dormant builds flagged at once — is each woken _once_, not once per notifier?   |
+| `test_limit_slot_wake`      | A concurrency slot frees — is the build queued on it woken, though it shares no task?   |
+| `test_suspended_blocker`    | A task suspended on dynamic children holds no claim. Is it waited on rather than reset? |
+| `test_failed_blocker`       | A shared task _failed_. Is that left alone as a result, rather than reset?              |
+| `test_watchdog_sweep`       | Does one sweep spawn a tick per build and return in seconds?                            |
+| `test_wide_fan_out`         | A layer wider than one pass may spawn — throttle, or stall?                             |
+| `test_scheduler_lease_live` | Does the lease serialize on real Postgres, and lapse on the real clock?                 |
+
+**Two apps are deployed, not one.** `registry-live-dag` runs everything
+except the watchdog sweep, which gets `registry-live-watchdog` to itself.
+The sweep lists running builds scoped by _reactive app name_, so a sweep
+driven against the shared app would spawn ticks for whatever else was
+running at that moment — waking the dormant builds that four other
+scenarios assert cannot be woken by anything but the mechanism they test.
+They would not fail; they would quietly stop meaning anything. The
+environment stays shared, because it is the unit of teardown; only the app
+name separates them, and the image is identical so the extra deploy is
+seconds.
 
 **The registry runs its own Postgres inside its own Modal container.** There
 is no database account to create, nothing to provision and nothing to clean
@@ -254,11 +278,40 @@ profile name.
 
 ##### Concurrency, and turning it off
 
-The scenarios run concurrently (`-n 4`). They are almost entirely sleep —
-each waits on Modal containers it does not own — so running them together
-costs little more than running the longest, and the tier's runtime stops
-being the sum of its parts as scenarios are added. They share one registry
-container, which serves them concurrently, and each salts its own task ids.
+The scenarios run concurrently (`-n 12`, sized to the scenario count). They
+are almost entirely sleep — each waits on Modal containers it does not own —
+so running them together costs little more than running the longest, and the
+tier's runtime is the length of its slowest scenario rather than the sum of
+its parts. They share one registry container, which serves them concurrently,
+and each salts its own task ids.
+
+Measured: **~3.5 minutes** for the twelve tests, plus ~40s to provision.
+The bound is `test_suspended_blocker` at ~200s — it has to hold a task
+RUNNING long enough for a second build to register against it, then
+SUSPENDED long enough for that build to tick while it is.
+
+**Wait on a state, never on a clock.** Every scenario here rests on an
+ordering — a second build registering while a task is still RUNNING, a tick
+landing while one is SUSPENDED — and a `sleep` sized for that window is wrong
+in both directions. It is wall clock on every run, and on the one run where
+Modal is slow to start a container it silently produces the situation it was
+meant to prevent: a scenario that still passes while testing something
+weaker. `_wait.wait_for_task_status` is the alternative, and where a window
+is a guess about infrastructure rather than about scheduling, the scenario
+asserts the ordering actually held and says which constant to raise if it
+did not.
+
+**A scenario that needs its second build woken _twice_ should keep that
+build resident instead.** `select_wake_candidates` hands a flagged build
+out at most once per 120s window and does not compare the flag's timestamp
+against the hand-out's — so a build re-flagged after being handed out
+waits for the window to lapse, and then needs someone to drain. In the
+full concurrent tier another scenario's tick does that (drains are not
+scoped to the caller's build), so such a scenario passes here and hangs
+under `-n0`. The watchdog is the production backstop for it, and this tier
+runs none. The two blocker scenarios keep their second build resident for
+this reason — which is the better shape anyway, since what they test is
+what a tick _decides_, not who called it.
 
 **When something fails, run them one at a time.** A shared registry and
 interleaved logs make a low-level failure much harder to read:

--- a/integration-tests/src/stardag_integration_tests/registry_live/_deployed.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_deployed.py
@@ -1,0 +1,52 @@
+"""Calling a deployed app's own functions.
+
+Almost nothing here needs this. The scenarios trigger a build and then
+watch, because what they are testing is precisely that nobody had to
+intervene: the registry flags a wake candidate on *every* task status
+transition, so a build that needs another tick gets one without being
+asked. A test that drove ticks by hand would be racing those, and would as
+often as not be told the scheduler lease is already held -- a tick that
+reports nothing about the situation it was called to judge.
+
+The exception is the watchdog sweep, which is a deployed function with no
+other way in. It never fires on its own here: both apps deploy with the
+periodic schedule off, deliberately, since a sweep running in the
+background would eventually complete every build in the tier and none of
+the other scenarios would prove anything.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def deployed_function(app_name: str, function_name: str, modal_environment: str):
+    """A handle on one function of a deployed app.
+
+    ``environment_name`` is passed explicitly rather than left to the
+    ambient ``MODAL_ENVIRONMENT``. This tier's whole safety story is that
+    everything it touches lives in the run's own environment, and a lookup
+    that silently resolved elsewhere would reach into a workspace that also
+    holds standing deployments.
+    """
+    import modal
+
+    return modal.Function.from_name(
+        app_name, function_name, environment_name=modal_environment
+    )
+
+
+def run_watchdog_sweep(*, app_name: str, modal_environment: str) -> float:
+    """Drive one watchdog sweep. Returns how long the call took, in seconds.
+
+    The duration is an observable in its own right, not instrumentation.
+    The sweep's contract is that it *dispatches* -- it lists the app's
+    running builds, spawns a tick for each, and returns -- so its cost has
+    to be independent of how many builds it found. An implementation that
+    ran the tick bodies inline would be correct in every other respect and
+    would show up here, as a call that takes as long as the work does.
+    """
+    function = deployed_function(app_name, "tick_watchdog", modal_environment)
+    started = time.monotonic()
+    function.remote()
+    return time.monotonic() - started

--- a/integration-tests/src/stardag_integration_tests/registry_live/_events.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_events.py
@@ -28,20 +28,30 @@ from ._harness import Deployment
 RESET_EVENT = "task_retried"
 
 
-def task_events(deployment: Deployment, task_id: Any) -> list[dict[str, Any]]:
+def task_events(
+    deployment: Deployment, task_id: Any, *, missing_ok: bool = False
+) -> list[dict[str, Any]]:
     """Every event recorded against one task, across all builds, oldest first.
-
-    ``task_id`` is the stardag task id (the parameter hash), not the
-    registry's row UUID -- the same string ``task.id`` gives.
 
     The API answers newest first; reversed here because these read as a
     story and a story runs forwards.
+
+    ``missing_ok`` decides what an unregistered task means, and the default
+    is the strict reading on purpose. At assertion time a task the registry
+    has never heard of is a real failure and must not read as "no resets
+    happened" -- an empty list is the answer this function's callers treat
+    as *proof of correct behaviour*. Only a caller that is polling *for*
+    the registration should pass True, where 404 is the expected first
+    answer rather than a problem; that mirrors the None-for-missing
+    contract ``_wait.task_status`` documents for the same situation.
     """
     with httpx.Client(timeout=60.0) as client:
         response = client.get(
             f"{deployment.api_url.rstrip('/')}/api/v1/tasks/{task_id}/events",
             headers={"X-API-Key": deployment.api_key},
         )
+        if missing_ok and response.status_code == 404:
+            return []
         response.raise_for_status()
         return list(reversed(response.json()))
 
@@ -107,9 +117,25 @@ def wait_until_registered(
     from ._wait import wait_until
 
     wait_until(
-        lambda: bool(events_by(task_events(deployment, task_id), build_id)),
+        lambda: bool(
+            events_by(task_events(deployment, task_id, missing_ok=True), build_id)
+        ),
         build_id=build_id,
         timeout=timeout,
         poll_interval=3.0,
         what=f"build {build_id} to register against task {task_id}",
     )
+
+
+def first_event_at(events: Iterable[dict[str, Any]], build_id: Any) -> str | None:
+    """When this build first touched the task, by the registry's clock.
+
+    Server-side timestamps on both ends is the point: a margin computed
+    from when a *client poll happened to notice* a transition is
+    systematically optimistic by up to one poll interval plus a round trip,
+    and a diagnostic that flatters itself is worse than none -- it reads
+    healthy right up to the moment the thing it is warning about starts
+    failing.
+    """
+    mine = events_by(events, build_id)
+    return str(mine[0]["created_at"]) if mine else None

--- a/integration-tests/src/stardag_integration_tests/registry_live/_events.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_events.py
@@ -1,0 +1,115 @@
+"""The task event log, which is the only place some questions are answered.
+
+Two scenarios here turn on whether a *particular build* reset a task it did
+not own. No status column can answer that. ``latest_status`` and
+``latest_status_build_id`` are one row per task, overwritten by whoever
+wrote last, so a build that resets a task and then watches someone else
+complete it leaves no trace in them at all -- the reset happened, and the
+columns show the completion. The append-only event log is where the reset
+is still visible, attributed to the build that made it.
+
+The registry client has no method for this endpoint, so these talk to the
+API directly with the deployment's own API key -- the same credential the
+workers use, and the same shape as the harness's other direct calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import httpx
+
+from ._harness import Deployment
+
+# A reset is recorded as this. It is what a build does to a failed,
+# cancelled or skipped task to make it its own to run again -- correct
+# within a build, and the thing a build must not do to a task another build
+# is legitimately mid-flight on.
+RESET_EVENT = "task_retried"
+
+
+def task_events(deployment: Deployment, task_id: Any) -> list[dict[str, Any]]:
+    """Every event recorded against one task, across all builds, oldest first.
+
+    ``task_id`` is the stardag task id (the parameter hash), not the
+    registry's row UUID -- the same string ``task.id`` gives.
+
+    The API answers newest first; reversed here because these read as a
+    story and a story runs forwards.
+    """
+    with httpx.Client(timeout=60.0) as client:
+        response = client.get(
+            f"{deployment.api_url.rstrip('/')}/api/v1/tasks/{task_id}/events",
+            headers={"X-API-Key": deployment.api_key},
+        )
+        response.raise_for_status()
+        return list(reversed(response.json()))
+
+
+def events_by(events: Iterable[dict[str, Any]], build_id: Any) -> list[dict[str, Any]]:
+    """The subset of ``events`` this build wrote."""
+    wanted = str(build_id)
+    return [event for event in events if str(event.get("build_id")) == wanted]
+
+
+def resets_by(events: Iterable[dict[str, Any]], build_id: Any) -> list[dict[str, Any]]:
+    """The resets this build performed on the task -- normally none.
+
+    The decisive observable for both cross-build blocker scenarios: a
+    build that waited correctly has an empty list here, and a build that
+    reset a task another build was mid-flight on does not.
+    """
+    return [
+        event
+        for event in events_by(events, build_id)
+        if event.get("event_type") == RESET_EVENT
+    ]
+
+
+def describe_events(events: Iterable[dict[str, Any]], **labels: Any) -> str:
+    """The event log as lines, for putting in an assertion message.
+
+    ``labels`` names the builds -- ``describe_events(events, A=id_a, B=id_b)``
+    prints ``A`` and ``B`` rather than two UUIDs the reader has to match up
+    by eye, which is most of the work of reading one of these failures.
+    """
+    named = {str(value): name for name, value in labels.items()}
+    lines = []
+    for event in events:
+        build = str(event.get("build_id"))
+        lines.append(
+            f"  {str(event.get('created_at'))[11:19]} "
+            f"{event.get('event_type')} (build {named.get(build, build)})"
+        )
+    return "\n".join(lines) or "  (no events recorded against this task)"
+
+
+def wait_until_registered(
+    deployment: Deployment,
+    *,
+    task_id: Any,
+    build_id: Any,
+    timeout: float = 300.0,
+) -> None:
+    """Block until ``build_id`` has an event of its own on this task.
+
+    Build membership comes from the event log, not from the task's status
+    columns: a task with no task-level event for a build is not in that
+    build, however its columns read. A seeded build showing an empty task
+    list and an empty DAG is the correct rendering of that, and has been
+    mistaken for a bug.
+
+    The cross-build scenarios need this because "B has been triggered" is
+    not the precondition any of them actually require -- "B has registered
+    against the shared task, and the task was still in the right status
+    when it did" is.
+    """
+    from ._wait import wait_until
+
+    wait_until(
+        lambda: bool(events_by(task_events(deployment, task_id), build_id)),
+        build_id=build_id,
+        timeout=timeout,
+        poll_interval=3.0,
+        what=f"build {build_id} to register against task {task_id}",
+    )

--- a/integration-tests/src/stardag_integration_tests/registry_live/_scenario_app.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_scenario_app.py
@@ -54,11 +54,28 @@ image = sd_modal.with_stardag_on_image(
     modal.Image.debian_slim(python_version=python_version)
 ).add_local_python_source("stardag_integration_tests")
 
-# The deployed ``tick`` function's own Modal timeout. Named because a
-# scenario asserts against it: it is what the per-tick spawn cap is derived
-# from, so a fan-out scenario reasoning about the cap has to read the same
-# number the tick reads rather than restating it.
+# The deployed ``tick`` function's own Modal timeout. Named here so a
+# scenario can read it rather than restate it -- see ``MAX_LINGER_SECONDS``.
 TICK_TIMEOUT_SECONDS = 300
+
+# The longest linger a tick can actually honour, and the reason a scenario
+# must not simply ask for the timeout itself.
+#
+# A linger is a deadline the tick body watches; the Modal timeout is a
+# deadline the *container* is killed on, and the container's clock starts
+# first -- before the image loads, before the tick body runs. So the two are
+# not a tie at equal values: Modal always wins. A tick that reaches a linger
+# equal to its timeout is killed rather than exiting through
+# ``lingered_out``, which means it writes no summary and performs no exit
+# hand-off. In this tier that is unrecoverable, because there is no watchdog
+# to spawn a replacement: a build that genuinely stalls hangs to the pytest
+# timeout and reports it as the tick having died mid-report, which points
+# at the wrong thing entirely.
+#
+# The margin is generous because it is covering a container start, and
+# nothing is paid for it: a tick exits as soon as its build goes terminal,
+# so a linger is an upper bound that a passing run never reaches.
+MAX_LINGER_SECONDS = TICK_TIMEOUT_SECONDS - 60
 
 
 def build_scenario_app(app_name: str) -> sd_modal.StardagApp:

--- a/integration-tests/src/stardag_integration_tests/registry_live/_scenario_app.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_scenario_app.py
@@ -1,0 +1,93 @@
+"""The ``StardagApp`` the registry-live scenarios execute on.
+
+Deployed into the run's own Modal environment, alongside the registry it
+reports to. Its workers pick the API key up from the ``stardag-api-key``
+Modal secret that the connect flow pushed into that same environment -- so
+unlike the ``modal_live`` tier, where every registry is a NoOp stand-in,
+these workers really do talk to a registry over the network. That is the
+whole subject of this tier.
+
+**The interpreter that imports this module is load-bearing.** The image's
+Python is derived from it below and the app's functions are serialized, so
+whatever deploys an app and whatever triggers a build afterwards must agree
+on the Python minor version. They need not be the same checkout -- the local
+SDK only mints the build and spawns the bootstrap, and every tick after that
+runs in Modal against the deployed image. A mismatch is not a graceful
+error: the container dies with ``Runner segmentation fault (SIGSEGV), exit
+code: 139``, no traceback, and leaves a build RUNNING with no tasks and
+``reactive_app_name`` still null, because the reactive marker is written
+last. In the UI that reads as "the build is empty". The line printed on
+import puts the version where anyone reading the output will see it.
+
+**Why this is a factory rather than one module-level app.** Two apps are
+deployed from it, differing only in name -- see ``watchdog_app``. The
+sweep the watchdog scenario drives lists running builds scoped by
+*reactive app name*, so it would otherwise reach every other scenario's
+builds in the shared environment and wake the dormant ones, which is
+exactly the "nothing else could have woken it" that four other scenarios
+rest on. A second app name is the whole isolation, and it is cheap: the
+image is identical, so Modal reuses its layers.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import modal
+
+import stardag.integration.modal as sd_modal
+
+from .selectors import registry_live_limit_keys
+
+python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+print(
+    f"[registry-live] python {python_version} "
+    "-- deploys and triggers must agree on this",
+    file=sys.stderr,
+)
+
+# Installs the *local* checkout when the SDK reports a dev version, which is
+# what makes this an end-to-end test of the branch rather than of the last
+# PyPI release.
+image = sd_modal.with_stardag_on_image(
+    modal.Image.debian_slim(python_version=python_version)
+).add_local_python_source("stardag_integration_tests")
+
+# The deployed ``tick`` function's own Modal timeout. Named because a
+# scenario asserts against it: it is what the per-tick spawn cap is derived
+# from, so a fan-out scenario reasoning about the cap has to read the same
+# number the tick reads rather than restating it.
+TICK_TIMEOUT_SECONDS = 300
+
+
+def build_scenario_app(app_name: str) -> sd_modal.StardagApp:
+    """A scenario app under ``app_name``. Identical but for the name."""
+    return sd_modal.StardagApp(
+        app_name,
+        builder_settings=sd_modal.FunctionSettings(image=image, timeout=900),
+        worker_settings={
+            "default": sd_modal.FunctionSettings(image=image, timeout=600),
+        },
+        tick_settings=sd_modal.FunctionSettings(
+            image=image, timeout=TICK_TIMEOUT_SECONDS
+        ),
+        # **Off on both apps, and the scenarios depend on it being off.**
+        # The watchdog is a backstop that sweeps builds periodically; with
+        # it running, a build that completes proves only that *something*
+        # eventually noticed. The question this tier asks is whether the
+        # worker itself spawned the next tick, and the only way to ask it
+        # is to remove every other thing that could have.
+        #
+        # It is off on the watchdog app too. That app exists to have a
+        # sweep driven at a moment of the scenario's choosing, against a
+        # population it controls -- which a periodic sweep would spoil in
+        # the same way, by having already swept.
+        watchdog_period_minutes=None,
+        # A tick must be able to rebuild these from registry data alone,
+        # having imported only what the app declared -- see the tasks
+        # module.
+        task_modules=["stardag_integration_tests.registry_live.tasks"],
+        require_pickle_free=True,
+        limit_key_selector=registry_live_limit_keys,
+    )

--- a/integration-tests/src/stardag_integration_tests/registry_live/_wait.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_wait.py
@@ -263,3 +263,14 @@ def wait_for_task_status(
         poll_interval=poll_interval,
         what=f"task {task_id} to reach {' or '.join(wanted)}",
     )
+
+
+def build_status(build_id: UUID) -> str | None:
+    """One build's current status, as the registry currently reports it.
+
+    ``None`` where the registry has not derived one yet, which a caller
+    comparing against a named status handles for free.
+    """
+    from stardag.registry import registry_provider
+
+    return registry_provider.get().build_get(build_id).status

--- a/integration-tests/src/stardag_integration_tests/registry_live/_wait.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/_wait.py
@@ -10,7 +10,7 @@ regressed" and "the Modal worker never started".
 from __future__ import annotations
 
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from uuid import UUID
 
 TERMINAL = ("completed", "failed", "cancelled")
@@ -203,3 +203,63 @@ def _terminal_status(build_id: UUID) -> str | None:
 
     status = registry_provider.get().build_get(build_id).status
     return status if status in TERMINAL else None
+
+
+def task_status(task_id: UUID) -> str | None:
+    """One task's current status, or None if the registry has no row yet.
+
+    A single request against the task's own row, which is what makes it
+    cheap enough to poll. ``find_task`` answers a richer question and pages
+    through every task of a name to do it -- far too expensive to sit in a
+    loop.
+
+    None rather than an exception for the unregistered case, because it is
+    the *normal* first answer: a scenario starts polling as soon as it has
+    triggered a build, and the plan reaches the registry a moment later.
+    """
+    from stardag.registry import registry_provider
+    from stardag.exceptions import NotFoundError
+
+    try:
+        return registry_provider.get().task_get_metadata(task_id).status
+    except NotFoundError:
+        return None
+
+
+def wait_for_task_status(
+    task_id: UUID,
+    *,
+    expected: str | Sequence[str],
+    build_id: UUID,
+    timeout: float,
+    poll_interval: float = 3.0,
+) -> str:
+    """Block until ``task_id`` reaches one of ``expected``. Returns which.
+
+    **This is what a scenario should wait on, rather than sleeping.** Every
+    cross-build scenario here is built on an ordering -- a second build has
+    to register while a shared task is still RUNNING, a tick has to be
+    driven once a task is SUSPENDED -- and the ordering is the scenario. A
+    fixed sleep sized for that window is wrong in both directions: it is
+    longer than needed on a warm run, which is pure wall clock across a
+    tier of these, and too short whenever Modal takes an unusual time to
+    start a container, which silently converts the scenario into a
+    different and much weaker one that still passes.
+
+    Waiting for the state itself removes both. The timeout is then a real
+    timeout -- "this never happened" -- rather than a guess at how long it
+    ought to take.
+    """
+    wanted = (expected,) if isinstance(expected, str) else tuple(expected)
+
+    def reached() -> str | None:
+        status = task_status(task_id)
+        return status if status in wanted else None
+
+    return wait_until(
+        reached,
+        build_id=build_id,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        what=f"task {task_id} to reach {' or '.join(wanted)}",
+    )

--- a/integration-tests/src/stardag_integration_tests/registry_live/dag_app.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/dag_app.py
@@ -1,69 +1,15 @@
-"""The ``StardagApp`` the registry-live scenarios execute on.
+"""The app every scenario but one runs on.
 
-Deployed into the run's own Modal environment, alongside the registry it
-reports to. Its workers pick the API key up from the ``stardag-api-key``
-Modal secret that the connect flow pushed into that same environment -- so
-unlike the ``modal_live`` tier, where every registry is a NoOp stand-in,
-these workers really do talk to a registry over the network. That is the
-whole subject of this tier.
-
-**The interpreter that imports this module is load-bearing.** The image's
-Python is derived from it below and the app's functions are serialized, so
-whatever deploys the app and whatever triggers a build afterwards must agree
-on the Python minor version. They need not be the same checkout -- the local
-SDK only mints the build and spawns the bootstrap, and every tick after that
-runs in Modal against the deployed image. A mismatch is not a graceful
-error: the container dies with ``Runner segmentation fault (SIGSEGV), exit
-code: 139``, no traceback, and leaves a build RUNNING with no tasks and
-``reactive_app_name`` still null, because the reactive marker is written
-last. In the UI that reads as "the build is empty". The line printed on
-import puts the version where anyone reading the output will see it.
+A thin module on purpose: ``stardag modal deploy -m <module>`` deploys the
+``StardagApp`` it finds at module level, so each deployable app needs its
+own module even though the two here are built from the same factory. See
+``_scenario_app`` for what the app is and why there are two.
 """
 
 from __future__ import annotations
 
-import sys
-
-import modal
-
-import stardag.integration.modal as sd_modal
-
-from .selectors import registry_live_limit_keys
+from ._scenario_app import build_scenario_app
 
 APP_NAME = "registry-live-dag"
 
-python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-
-print(
-    f"[registry-live] python {python_version} "
-    "-- deploys and triggers must agree on this",
-    file=sys.stderr,
-)
-
-# Installs the *local* checkout when the SDK reports a dev version, which is
-# what makes this an end-to-end test of the branch rather than of the last
-# PyPI release.
-image = sd_modal.with_stardag_on_image(
-    modal.Image.debian_slim(python_version=python_version)
-).add_local_python_source("stardag_integration_tests")
-
-app = sd_modal.StardagApp(
-    APP_NAME,
-    builder_settings=sd_modal.FunctionSettings(image=image, timeout=900),
-    worker_settings={
-        "default": sd_modal.FunctionSettings(image=image, timeout=600),
-    },
-    tick_settings=sd_modal.FunctionSettings(image=image, timeout=300),
-    # **Off, and the scenarios depend on it being off.** The watchdog is a
-    # backstop that sweeps builds periodically; with it running, a build
-    # that completes proves only that *something* eventually noticed. The
-    # question this tier asks is whether the worker itself spawned the next
-    # tick, and the only way to ask it is to remove every other thing that
-    # could have.
-    watchdog_period_minutes=None,
-    # A tick must be able to rebuild these from registry data alone, having
-    # imported only what the app declared -- see the tasks module.
-    task_modules=["stardag_integration_tests.registry_live.tasks"],
-    require_pickle_free=True,
-    limit_key_selector=registry_live_limit_keys,
-)
+app = build_scenario_app(APP_NAME)

--- a/integration-tests/src/stardag_integration_tests/registry_live/provision.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/provision.py
@@ -133,7 +133,7 @@ def sdk_environment(deployment: Deployment) -> dict[str, str]:
 
 
 def up(modal_environment: str) -> Deployment:
-    """Deploy the registry, wire the SDK to it, deploy the scenario app."""
+    """Deploy the registry, wire the SDK to it, deploy the scenario apps."""
     _require_disposable_name(modal_environment, "provision into")
     _require_expected_workspace()
     repo_root = _repo_root()
@@ -157,7 +157,7 @@ def up(modal_environment: str) -> Deployment:
     os.environ.update(sdk_environment(deployment))
     os.environ.pop("STARDAG_PROFILE", None)
 
-    _deploy_dag_app(repo_root, modal_environment)
+    _deploy_dag_apps(repo_root, modal_environment)
 
     path = coordinates_path(modal_environment)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -166,7 +166,7 @@ def up(modal_environment: str) -> Deployment:
 
 
 def stop(modal_environment: str) -> None:
-    """Stop both apps, leaving the environment and its image cache.
+    """Stop every app in the stack, leaving the environment and its images.
 
     The counterpart to ``down`` for an environment that is meant to
     survive. The registry pins ``min_containers=1``, which keeps a
@@ -184,9 +184,8 @@ def stop(modal_environment: str) -> None:
     warm, which is what makes the next run's deploy take seconds.
     """
     _require_disposable_name(modal_environment, "stop apps in")
-    from .dag_app import APP_NAME
 
-    for app_name in (DEFAULT_REGISTRY_APP, APP_NAME):
+    for app_name in (DEFAULT_REGISTRY_APP, *(name for _, name in _scenario_apps())):
         stop_existing_app(app_name, modal_environment)
     coordinates_path(modal_environment).unlink(missing_ok=True)
 
@@ -195,7 +194,7 @@ def down(modal_environment: str) -> None:
     """Delete the Modal environment, and with it everything in the stack.
 
     One call removes the registry app, its container and therefore its
-    database, the scenario app, the target-root volume and the API-key
+    database, both scenario apps, the target-root volume and the API-key
     secret. That completeness is the reason the database lives inside the
     container rather than in a hosted service.
     """
@@ -364,42 +363,64 @@ def _ensure_modal_environment(name: str) -> None:
     raise SystemExit(f"Could not create Modal environment {name!r}: {output}")
 
 
-def _deploy_dag_app(repo_root: Path, modal_environment: str) -> None:
-    """Deploy the scenario app with the CLI from *this* environment.
+def _deploy_dag_apps(repo_root: Path, modal_environment: str) -> None:
+    """Deploy both scenario apps with the CLI from *this* environment.
 
-    Not a bare ``stardag`` off ``PATH``: the app's Modal functions are
+    Not a bare ``stardag`` off ``PATH``: an app's Modal functions are
     serialized by whatever interpreter imports the module, and every later
     trigger unpickles them in a container built for that Python. Resolving
     the CLI next to ``sys.executable`` makes the deploy and the scenarios
     agree by construction. A mismatch is not a graceful error -- the
     container dies with a bare SIGSEGV and leaves a build that looks empty.
+
+    The second app costs one more deploy of an image that is already built,
+    and buys the watchdog scenario a build population of its own -- see
+    ``watchdog_app``.
     """
-    from .dag_app import APP_NAME
-
-    # Warm containers from an earlier run hold the `stardag-api-key` secret
-    # as it was when they started, and connect has just *rotated* that key.
-    # A survivor authenticates with a revoked credential and takes a 401
-    # from the registry partway through a build.
-    stop_existing_app(APP_NAME, modal_environment)
-
     stardag_cli = Path(sys.executable).with_name("stardag")
     if not stardag_cli.exists():
         raise SystemExit(
             f"No stardag CLI next to {sys.executable}. This tier deploys with "
             "the CLI from its own environment on purpose -- see above."
         )
-    result = subprocess.run(
-        [str(stardag_cli), "modal", "deploy", "-m", f"{__package__}.dag_app"],
-        cwd=repo_root / "integration-tests",
-        capture_output=True,
-        text=True,
-        env={**os.environ, "MODAL_ENVIRONMENT": modal_environment},
-    )
-    if result.returncode != 0:
-        raise SystemExit(
-            f"Failed to deploy the scenario app:\n{result.stdout}\n{result.stderr}"
+
+    for module_name, app_name in _scenario_apps():
+        # Warm containers from an earlier run hold the `stardag-api-key`
+        # secret as it was when they started, and connect has just
+        # *rotated* that key. A survivor authenticates with a revoked
+        # credential and takes a 401 from the registry partway through a
+        # build.
+        stop_existing_app(app_name, modal_environment)
+
+        result = subprocess.run(
+            [str(stardag_cli), "modal", "deploy", "-m", module_name],
+            cwd=repo_root / "integration-tests",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "MODAL_ENVIRONMENT": modal_environment},
         )
-    print(f"[provision] deployed {APP_NAME!r}")
+        if result.returncode != 0:
+            raise SystemExit(
+                f"Failed to deploy {app_name!r}:\n{result.stdout}\n{result.stderr}"
+            )
+        print(f"[provision] deployed {app_name!r}")
+
+
+def _scenario_apps() -> list[tuple[str, str]]:
+    """(module, app name) for every app this tier deploys.
+
+    One list, read by both the deploy and the stop paths, so an app cannot
+    be added to one and forgotten in the other -- which would leave a
+    deployment with ``min_containers`` running after a `stop` that reported
+    success.
+    """
+    from .dag_app import APP_NAME as DAG_APP
+    from .watchdog_app import APP_NAME as WATCHDOG_APP
+
+    return [
+        (f"{__package__}.dag_app", DAG_APP),
+        (f"{__package__}.watchdog_app", WATCHDOG_APP),
+    ]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/integration-tests/src/stardag_integration_tests/registry_live/tasks.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/tasks.py
@@ -73,3 +73,101 @@ def slow(values: sd.Depends[list[int]], seconds: int, limit_key: str = "") -> li
     del limit_key  # read off the task by the app's limit-key selector
     time.sleep(seconds)
     return values
+
+
+@sd.task(name="Fails")
+def fails(values: sd.Depends[list[int]], seconds: int) -> list[int]:
+    """Runs for ``seconds``, then fails deterministically.
+
+    For the scenario where a shared task's status is a *result* rather than
+    a revocation. The sleep is what makes the decision observable: the
+    second build has to register while this task is still RUNNING, because
+    RUNNING is the one status a trigger will not reset -- and a trigger
+    resetting it is the (correct) behaviour that would hide the mid-flight
+    decision under test.
+    """
+    import time
+
+    time.sleep(seconds)
+    del values
+    raise RuntimeError("deliberate failure: this task exists to fail")
+
+
+class SuspendingParent(sd.Task[list[int]]):
+    """Registers dynamic children, yields, and so sits SUSPENDED while they run.
+
+    The shape one scenario needs and nothing else here produces: a shared
+    task whose worker registered its children, yielded and returned. It
+    holds **no claim** -- so nothing but its owning build's liveness says
+    whether anyone is still progressing it, and a second build that reset
+    it would redo every bit of the pre-yield work for nothing while the
+    first build is legitimately mid-flight.
+
+    Note which duration bounds that window. It is the *worker* timeout, not
+    the claim TTL: the TTL is derived from the timeout plus a grace, so it
+    is strictly the looser of the two, and a fixture sized against it would
+    be guaranteed to outlive its own execution budget.
+
+    ``salt`` reaches the leaf, and through it this task's own id and its
+    children's -- see the note on ``get_range``.
+    """
+
+    salt: str
+    children: int = 2
+    child_seconds: int = 60
+    pre_yield_seconds: int = 20
+
+    def requires(self):
+        return get_range(limit=self.children, salt=self.salt)
+
+    def run(self):
+        import time
+
+        indices = self.requires().load()
+        # A RUNNING window before the yield, and it is load-bearing rather
+        # than padding: the second build has to *register* while this task
+        # is still RUNNING. Register any later and plan closure follows the
+        # freshly-written dynamic edges, pulls the children into that
+        # build's plan too, and it is then simply a build with running
+        # tasks of its own -- never stalled, so never classifying a blocker
+        # at all. Correct behaviour; just not the state under test.
+        time.sleep(self.pre_yield_seconds)
+        # The children hang off the leaf this task already required, which
+        # is complete by the time they are registered -- so the suspended
+        # window costs one level of container start rather than two.
+        #
+        # Their ids are made distinct by the one parameter that was going
+        # to differ anyway. A task id is derived from its parameters, so
+        # two children given identical ones would be a single task and the
+        # fan-out would be imaginary.
+        kids = [
+            slow(values=self.requires(), seconds=self.child_seconds + index)
+            for index in indices
+        ]
+        yield kids
+        self._save([len(kid.load()) for kid in kids])
+
+
+class FanIn(sd.Task[int]):
+    """A single root over ``width`` independent leaves: one wide layer.
+
+    Flat rather than a binary tree, and that is the whole design. What the
+    fan-out scenario exercises is how many actionable tasks one tick pass
+    can put on workers, so the quantity that matters is the width of a
+    *single* layer. A tree over the same leaves would nearly double the
+    task count -- and every extra task is another real Modal container --
+    while making no layer any wider than this one.
+
+    Distinct ``limit`` values give the leaves distinct ids, so these really
+    are N independent tasks rather than one task referenced N times, which
+    is what makes it a fan-out rather than a deduplication test.
+    """
+
+    salt: str
+    width: int = 24
+
+    def requires(self):
+        return [get_range(limit=index, salt=self.salt) for index in range(self.width)]
+
+    def run(self):
+        self._save(sum(len(leaf.load()) for leaf in self.requires()))

--- a/integration-tests/src/stardag_integration_tests/registry_live/watchdog_app.py
+++ b/integration-tests/src/stardag_integration_tests/registry_live/watchdog_app.py
@@ -1,0 +1,27 @@
+"""A second app, whose only purpose is to own the watchdog scenario's builds.
+
+The sweep under test lists running builds **scoped by reactive app name**
+and spawns a tick for each. That scoping is what makes a separate app
+necessary rather than merely tidy: every scenario in this tier runs
+concurrently in one Modal environment, so a sweep driven against the shared
+app would spawn ticks for whatever else happened to be running at that
+moment -- waking the dormant builds that four other scenarios assert
+*cannot* be woken by anything but the mechanism they are testing. The
+scenarios would not fail; they would quietly stop meaning anything, which is
+the worse outcome.
+
+Separating by app name rather than by Modal environment is deliberate. The
+environment is this tier's unit of teardown -- one ``modal environment
+delete`` takes the registry, its database, the apps, the volume and the
+secret together -- and a second environment would need its own registry to
+report to, which is the expensive half of the stack. Two apps against one
+registry cost an extra deploy of an image that is already built.
+"""
+
+from __future__ import annotations
+
+from ._scenario_app import build_scenario_app
+
+APP_NAME = "registry-live-watchdog"
+
+app = build_scenario_app(APP_NAME)

--- a/integration-tests/tests_registry_live/test_cross_build_wake.py
+++ b/integration-tests/tests_registry_live/test_cross_build_wake.py
@@ -36,6 +36,7 @@ from stardag_integration_tests.registry_live._wait import (
     assert_trail_complete,
     describe,
     tick_summaries,
+    wait_for_task_status,
     wait_for_terminal,
 )
 
@@ -48,20 +49,17 @@ pytestmark = [
 
 # The shared task must outlive B's tick by a clear margin. These two
 # numbers are the scenario; if they ever cross, it silently degrades into
-# "a tick watched a task finish" and still passes.
-SHARED_SLEEP_SECONDS = 90
-B_LINGER_SECONDS = 20
+# "a tick watched a task finish" and still passes. The assertion on B's
+# first tick outcome is what catches that, which is what allows these to be
+# sized tightly rather than padded.
+SHARED_SLEEP_SECONDS = 75
+B_LINGER_SECONDS = 15
 
-# Let A claim and start the shared task before B is triggered, so B meets
-# it RUNNING and waits rather than racing for it.
-LET_A_CLAIM_SECONDS = 40
-
+STATUS_TIMEOUT_SECONDS = 300
 BUILD_TIMEOUT_SECONDS = 600
 
 
 def test_a_blockers_completion_wakes_a_dormant_build() -> None:
-    import time
-
     from stardag_integration_tests.registry_live.dag_app import app
     from stardag_integration_tests.registry_live.tasks import (
         get_range,
@@ -80,10 +78,21 @@ def test_a_blockers_completion_wakes_a_dormant_build() -> None:
         reactive=True,
         # A lingers long enough to see its own work through, so that the
         # only build depending on a wake-up is B.
-        tick_kwargs={"linger_seconds": 200, "poll_interval_seconds": 3},
+        tick_kwargs={"linger_seconds": 150, "poll_interval_seconds": 3},
     ).build_id
 
-    time.sleep(LET_A_CLAIM_SECONDS)
+    # Let A claim and start the shared task before B is triggered, so B
+    # meets it RUNNING and waits rather than racing for it. Waiting on the
+    # status rather than sleeping a guess at how long that takes: the guess
+    # is wall clock on every run, and is wrong in the one case that matters
+    # -- a slow container start, where it silently produces the racing B it
+    # was meant to prevent.
+    wait_for_task_status(
+        shared.id,
+        expected="running",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
 
     build_b = app.build_trigger(
         square(values=shared, offset=11),
@@ -116,9 +125,9 @@ def test_a_blockers_completion_wakes_a_dormant_build() -> None:
     assert summaries_b[0].get("outcome") == "lingered_out", (
         "Build B's first tick did not linger out, so it may have been "
         "resident when the blocker completed and noticed on its own poll. "
-        f"The shared task's sleep ({SHARED_SLEEP_SECONDS}s) must comfortably "
-        f"outlast B's linger ({B_LINGER_SECONDS}s) plus the "
-        f"{LET_A_CLAIM_SECONDS}s head start.\n" + describe(build_b)
+        f"The shared task's sleep ({SHARED_SLEEP_SECONDS}s) must "
+        f"comfortably outlast B's linger ({B_LINGER_SECONDS}s) plus B's "
+        "bootstrap.\n" + describe(build_b)
     )
     assert len(summaries_b) > 1, (
         "Build B ran exactly one tick, so it cannot have been woken.\n"

--- a/integration-tests/tests_registry_live/test_failed_blocker.py
+++ b/integration-tests/tests_registry_live/test_failed_blocker.py
@@ -50,6 +50,7 @@ from stardag_integration_tests.registry_live._events import (
     wait_until_registered,
 )
 from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._scenario_app import MAX_LINGER_SECONDS
 from stardag_integration_tests.registry_live._harness import Deployment
 from stardag_integration_tests.registry_live._wait import (
     assert_trail_complete,
@@ -74,10 +75,12 @@ pytestmark = [
 FAIL_AFTER_SECONDS = 60
 
 # B stays resident across the whole window, so its own polling tick is
-# the one that meets the failure -- see the module docstring. This costs
-# nothing in wall clock: a tick exits as soon as its build goes terminal,
-# so the linger is an upper bound that is never reached.
-LINGER_SECONDS = 300
+# the one that meets the failure -- see the module docstring. Read from the
+# app rather than restated: a linger equal to the tick's own Modal timeout
+# is not a tie, because the container's clock starts first, so such a tick
+# is killed instead of exiting through ``lingered_out`` -- writing no
+# summary and running no exit hand-off. See MAX_LINGER_SECONDS.
+LINGER_SECONDS = MAX_LINGER_SECONDS
 
 STATUS_TIMEOUT_SECONDS = 300
 BUILD_TIMEOUT_SECONDS = 600

--- a/integration-tests/tests_registry_live/test_failed_blocker.py
+++ b/integration-tests/tests_registry_live/test_failed_blocker.py
@@ -1,0 +1,202 @@
+"""A shared task's failure is a *result*, and a waiting build must leave it.
+
+The mirror image of the suspended case, and the distinction between them is
+the whole point. A task another build is mid-flight on must be waited for; a
+task that has *failed* must be left entirely alone. Both come down to "do
+not reset it", for opposite reasons -- one because the work is still
+happening, the other because it has already finished and produced an answer.
+
+A failure belongs to the failing build's ``fail_mode``, which is a policy
+its owner chose. FAIL_FAST has already failed that build on the same count;
+CONTINUE means "finish what you can, then fail". A second build that reset
+the task would override that policy, on nobody's request, and re-run work
+that had a verdict. (A *re-trigger* is different and is allowed to reset the
+whole retryable set -- there the user did ask.)
+
+Two things about the construction, both of which the scenario would be
+meaningless without:
+
+**B must register while the shared task is still RUNNING.** A trigger runs
+discovery with ``retry_failed=True`` and resets the retryable set, so a B
+triggered after the failure resets the task in its own bootstrap -- correct,
+because at trigger time you did ask, and it hides the mid-flight decision
+completely. RUNNING is the one status a trigger will not reset, which is why
+the task sleeps before failing.
+
+**Both builds run with ``fail_mode=continue``.** Under FAIL_FAST the build
+fails on the status count before terminal evaluation ever looks at a
+blocker. A additionally gets ``max_attempts=1`` so it does not reset the
+task itself -- a reset would put it back to PENDING, where B could claim it
+legitimately and the shared-failure shape would be gone.
+
+**B is resident**, unlike the second build in the wake-up scenarios. What
+is under test is what a tick *decides* when it looks at a blocker it does
+not own, not who called that tick, and keeping B's own scheduler alive
+across the window isolates the decision from the delivery machinery --
+which is tested on its own elsewhere. It also removes a cold container
+start from the middle of the run.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._events import (
+    describe_events,
+    resets_by,
+    task_events,
+    wait_until_registered,
+)
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._harness import Deployment
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    task_status,
+    tick_summaries,
+    wait_for_task_status,
+    wait_for_terminal,
+)
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# How long the shared task runs before failing. The window B has to
+# register in, sized against a cold Modal container for B's bootstrap --
+# not against anything in the decision under test. The run checks the
+# ordering actually held rather than trusting the number.
+FAIL_AFTER_SECONDS = 60
+
+# B stays resident across the whole window, so its own polling tick is
+# the one that meets the failure -- see the module docstring. This costs
+# nothing in wall clock: a tick exits as soon as its build goes terminal,
+# so the linger is an upper bound that is never reached.
+LINGER_SECONDS = 300
+
+STATUS_TIMEOUT_SECONDS = 300
+BUILD_TIMEOUT_SECONDS = 600
+
+
+def test_a_failed_blocker_is_left_alone_by_a_second_build(
+    deployment: Deployment,
+) -> None:
+    from stardag_integration_tests.registry_live.dag_app import app
+    from stardag_integration_tests.registry_live.tasks import (
+        fails,
+        get_range,
+        get_sum,
+        square,
+    )
+
+    salt = uuid.uuid4().hex
+
+    leaf = get_range(limit=7, salt=salt)
+    shared = fails(values=leaf, seconds=FAIL_AFTER_SECONDS)
+
+    build_a = app.build_trigger(
+        get_sum(integers=shared),
+        reactive=True,
+        tick_kwargs={
+            "fail_mode": "continue",
+            # No second attempt: a retry by A would put the task back to
+            # PENDING, where B may legitimately claim it, and the shared
+            # *failure* this scenario needs would never exist.
+            "max_attempts": 1,
+            "linger_seconds": 120,
+            "poll_interval_seconds": 3,
+        },
+    ).build_id
+
+    wait_for_task_status(
+        shared.id,
+        expected="running",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    build_b = app.build_trigger(
+        square(values=shared, offset=3),
+        reactive=True,
+        tick_kwargs={
+            "fail_mode": "continue",
+            # Default attempt budget, and none of it spent on the shared
+            # task in B's own round -- so the budget *permits* a reset and
+            # the blocker's status is what refuses it. Capping attempts
+            # here would let the test pass for the wrong reason.
+            "linger_seconds": LINGER_SECONDS,
+            "poll_interval_seconds": 3,
+        },
+    ).build_id
+
+    wait_until_registered(deployment, task_id=shared.id, build_id=build_b)
+    status_when_registered = task_status(shared.id)
+    assert status_when_registered == "running", (
+        f"Build B registered against the shared task when it was already "
+        f"{status_when_registered!r}, not RUNNING. A trigger resets the "
+        "retryable set, so a B that arrives after the failure resets the "
+        "task in its own bootstrap and the mid-flight decision never "
+        f"happens. Raise FAIL_AFTER_SECONDS (currently "
+        f"{FAIL_AFTER_SECONDS}s) so B's bootstrap fits inside the window.\n"
+        + describe(build_b)
+    )
+
+    wait_for_task_status(
+        shared.id,
+        expected="failed",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    # Both builds are expected to fail: neither can finish, because the
+    # only route to either root is through a task that produced a failure
+    # and that nothing here is going to re-run. Waiting for terminal is
+    # also what guarantees B's post-failure tick has happened and reported.
+    status_a = wait_for_terminal(build_a, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_a == "failed", (
+        f"Build A ended {status_a!r}. Its only path runs through a task "
+        "that fails deterministically, so it cannot complete.\n" + describe(build_a)
+    )
+    status_b = wait_for_terminal(build_b, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_b == "failed", (
+        f"Build B ended {status_b!r}. It should have failed on a blocker "
+        "whose status is a result -- if it completed, it re-ran the shared "
+        "task, which is exactly what must not happen.\n" + describe(build_b)
+    )
+
+    # The decisive observable. B failed either way; whether it *reset* the
+    # task on the way there is what separates correct from expensive, and
+    # only the event log records it -- the status columns show whoever
+    # wrote last.
+    events = task_events(deployment, shared.id)
+    resets = resets_by(events, build_b)
+    assert not resets, (
+        "Build B reset the shared task after it failed under build A. A "
+        "failure is a result, and results belong to the failing build's "
+        "fail_mode -- resetting it overrides a policy its owner chose and "
+        "re-runs work that already has a verdict.\n"
+        f"--- events on the shared task ---\n"
+        f"{describe_events(events, A=build_a, B=build_b)}"
+    )
+
+    summaries_b = tick_summaries(build_b)
+    assert_trail_complete(build_b, summaries_b)
+
+    reset_count = sum(s.get("in_build_blockers_reset", 0) for s in summaries_b)
+    assert reset_count == 0, (
+        f"Build B's ticks reset a blocker in its own plan {reset_count} "
+        "time(s). The failed task was the only blocker there.\n" + describe(build_b)
+    )
+
+    # B never ran the shared task, nor anything downstream of it -- its
+    # root was unreachable from the moment the blocker failed.
+    spawned_b = sum(s.get("spawned", 0) for s in summaries_b)
+    assert spawned_b == 0, (
+        f"Build B spawned {spawned_b} task(s). With its only upstream "
+        "failed and left alone, there was nothing for it to run.\n" + describe(build_b)
+    )

--- a/integration-tests/tests_registry_live/test_limit_slot_wake.py
+++ b/integration-tests/tests_registry_live/test_limit_slot_wake.py
@@ -1,0 +1,193 @@
+"""Freeing a concurrency slot wakes the build that was queued on it.
+
+A second wake-up mechanism, and it is genuinely a different one from the
+cross-build case next door. There the news is about a *task*: a build holds
+the task whose status changed, so the registry knows to flag it. Here the
+two builds share no task at all. They want different work; they are queued
+behind the same named limit, and the only thing connecting them is a
+counter.
+
+That makes the "who needs to hear about this?" question harder in a way
+worth testing live: on a transition out of RUNNING the registry has to flag
+not only the builds holding *that task* but the builds holding a PENDING
+task under any limit key it was occupying. Nothing in the waiting build's
+own state points at the task that freed the slot.
+
+Without that flag the wait ends only at the watchdog, which this app does
+not run at all. So if B finishes, the slot release reached across.
+
+The limit is set here rather than assumed, and torn down afterwards. It is
+environment-global -- one number shared by everything running against this
+registry -- which is exactly why the app's key selector is **opt-in**: only
+a task that asks for the key gets it, so no other scenario's work is
+accounted against this limit or woken by its release.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    tick_summaries,
+    wait_for_task_status,
+    wait_for_terminal,
+)
+from stardag_integration_tests.registry_live.selectors import SLOW_LIMIT_KEY
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# A's task holds the single slot for this long. It has to outlive B's
+# linger by a clear margin, or B is still resident when the slot frees and
+# notices on its own poll -- which would pass while testing nothing.
+A_SLOW_SECONDS = 60
+B_LINGER_SECONDS = 15
+
+# B's own task is short: once it has the slot there is nothing to prove by
+# making it wait.
+B_SLOW_SECONDS = 5
+
+STATUS_TIMEOUT_SECONDS = 300
+BUILD_TIMEOUT_SECONDS = 600
+
+
+@pytest.fixture
+def slot_limit():
+    """One slot for the scenario's key, removed again afterwards.
+
+    Torn down because the limit outlives the build that needed it: a stack
+    is meant to be kept and re-run against, and a leftover cap of 1 would
+    silently serialize a later run of this same scenario against the
+    previous one's leftovers.
+    """
+    from stardag.registry import registry_provider
+
+    registry = registry_provider.get()
+    registry.concurrency_limit_set(SLOW_LIMIT_KEY, 1)
+    try:
+        yield
+    finally:
+        registry.concurrency_limit_delete(SLOW_LIMIT_KEY)
+
+
+def test_releasing_a_slot_wakes_the_build_queued_on_it(slot_limit) -> None:
+    from stardag_integration_tests.registry_live.dag_app import app
+    from stardag_integration_tests.registry_live.tasks import (
+        get_range,
+        get_sum,
+        slow,
+    )
+
+    salt = uuid.uuid4().hex
+
+    # Two *different* slow tasks. The builds share no task whatsoever --
+    # only the limit key -- which is what distinguishes this from the
+    # cross-build wake-up.
+    a_slow = slow(
+        values=get_range(limit=8, salt=salt),
+        seconds=A_SLOW_SECONDS,
+        limit_key=SLOW_LIMIT_KEY,
+    )
+    b_slow = slow(
+        values=get_range(limit=9, salt=salt),
+        seconds=B_SLOW_SECONDS,
+        limit_key=SLOW_LIMIT_KEY,
+    )
+
+    build_a = app.build_trigger(
+        get_sum(integers=a_slow),
+        reactive=True,
+        # A stays resident through its own work, so that the only build
+        # depending on a wake-up is B.
+        tick_kwargs={"linger_seconds": 180, "poll_interval_seconds": 3},
+    ).build_id
+
+    # Let A actually take the slot before B asks for one, so B is *denied*
+    # rather than racing A for it. Waiting on the task's status is what
+    # makes that certain -- a fixed sleep would only make it likely.
+    wait_for_task_status(
+        a_slow.id,
+        expected="running",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    build_b = app.build_trigger(
+        get_sum(integers=b_slow),
+        reactive=True,
+        tick_kwargs={
+            "linger_seconds": B_LINGER_SECONDS,
+            "poll_interval_seconds": 3,
+        },
+    ).build_id
+
+    status_a = wait_for_terminal(build_a, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_a == "completed", describe(build_a)
+
+    # B is the subject. If the slot release did not reach it, this hangs.
+    status_b = wait_for_terminal(build_b, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_b == "completed", (
+        "Build B never finished. Its task was denied the only slot of a "
+        "named concurrency limit, the holder completed and freed it, and "
+        "nothing told B. B shares no task with A, so the flag has to come "
+        "from the limit key the finishing task held.\n"
+        f"--- build A ---\n{describe(build_a)}\n"
+        f"--- build B ---\n{describe(build_b)}"
+    )
+
+    summaries_b = tick_summaries(build_b)
+    assert_trail_complete(build_b, summaries_b)
+
+    # B really was denied the slot rather than merely being slow to start.
+    # Without this the test would pass just as well with no limit set at
+    # all, which is the failure mode worth guarding against here.
+    denied = sum(s.get("limit_denied", 0) for s in summaries_b)
+    assert denied >= 1, (
+        "No tick of build B was ever denied a concurrency slot, so the "
+        f"limit on {SLOW_LIMIT_KEY!r} was not in force and B simply ran. "
+        "Nothing about slot-release wake-ups was exercised.\n" + describe(build_b)
+    )
+
+    # And B was dormant when the slot freed: its first tick gave up and
+    # left, so the tick that finished it was spawned by the wake-up rather
+    # than being something B had left running.
+    assert summaries_b[0].get("outcome") == "lingered_out", (
+        "Build B's first tick did not linger out, so it may still have "
+        "been resident when the slot freed and seen it on its own poll. "
+        f"A's task ({A_SLOW_SECONDS}s) must comfortably outlast B's linger "
+        f"({B_LINGER_SECONDS}s).\n" + describe(build_b)
+    )
+    assert len(summaries_b) > 1, (
+        "Build B ran exactly one tick, so it cannot have been woken.\n"
+        + describe(build_b)
+    )
+
+    # Nothing is asserted about *which* process spawned B's wake-up tick,
+    # and the omission is deliberate rather than an oversight.
+    #
+    # An earlier version required A's tick trail to show a
+    # `neighbour_ticks_spawned`, on the reasoning that A's side must have
+    # done the waking. It failed on the first live run, and it was the
+    # assertion that was wrong: A's whole build fitted inside a single
+    # resident tick, and the drain that woke B was performed by A's
+    # *worker* on the status write that freed the slot. A worker's drains
+    # appear in no tick trail at all.
+    #
+    # Both routes are the mechanism working. Every notifier drains -- the
+    # worker on its status write, the tick on its pass and again on its
+    # exit -- precisely so that no single one of them is load-bearing, and
+    # a test that named one turned that redundancy into a failure.
+    #
+    # What the assertions above already establish needs no such help: B was
+    # denied the slot, B's own scheduler left, B later completed, and no
+    # watchdog runs here. There is no route to that except the release
+    # reaching across.

--- a/integration-tests/tests_registry_live/test_limit_slot_wake.py
+++ b/integration-tests/tests_registry_live/test_limit_slot_wake.py
@@ -64,10 +64,12 @@ BUILD_TIMEOUT_SECONDS = 600
 def slot_limit():
     """One slot for the scenario's key, removed again afterwards.
 
-    Torn down because the limit outlives the build that needed it: a stack
-    is meant to be kept and re-run against, and a leftover cap of 1 would
-    silently serialize a later run of this same scenario against the
-    previous one's leftovers.
+    Torn down because a concurrency limit is environment-global and
+    outlives the run that set it. Nothing else opts into this key today, so
+    the leftover would be harmless today -- but it is a piece of registry
+    configuration silently left behind on a stack meant to be kept and
+    re-run against, and the next task to ask for the key would be
+    serialized by a cap nobody set on purpose.
     """
     from stardag.registry import registry_provider
 

--- a/integration-tests/tests_registry_live/test_suspended_blocker.py
+++ b/integration-tests/tests_registry_live/test_suspended_blocker.py
@@ -1,0 +1,253 @@
+"""A task suspended on its dynamic children must be waited on, not reset.
+
+The hardest case in the cross-build family, because the task under
+contention is holding nothing. A worker that registers dynamic children,
+yields and returns leaves the task SUSPENDED -- and a suspended task has
+**no execution claim**. There is no lease to inspect, no expiry to compare
+a clock against. The only thing that says somebody is still progressing it
+is the liveness of the build that owns it.
+
+So a second build arriving at that task is being asked to distinguish
+"abandoned, mine to take" from "mid-flight, leave it alone" with the
+evidence deliberately removed. Getting it wrong is expensive rather than
+merely wrong: resetting the task discards every bit of pre-yield work and
+races the owning build's own scheduling of the children it just registered.
+
+Note which duration bounds that window, because getting it backwards has
+killed runs. It is the **worker timeout**, not the claim TTL -- the TTL is
+derived from the timeout plus a grace, so it is strictly the looser of the
+two, and a fixture sized against the TTL would be guaranteed to outlive its
+own execution budget.
+
+The decisive observable is in the event log, and only there. Status columns
+are one row per task overwritten by whoever wrote last, so a build that
+reset this task and then watched the other build complete it leaves no mark
+on them at all: the reset happened, and the columns show a completion.
+``task_retried`` attributed to B is the thing that either exists or does
+not.
+
+**B is resident here, and deliberately.** Every other cross-build scenario
+makes the second build dormant, because what they test is the wake-up
+reaching it. This one is not about who calls the tick -- it is about what a
+tick *decides* when it looks at a blocker it does not own. Keeping B's
+scheduler alive across the whole window isolates that decision from the
+delivery machinery, which is tested on its own next door.
+
+It is also the difference between a scenario that works and one that works
+most of the time. A dormant B has to be woken twice here -- once when the
+task suspends, once when it completes -- and the server hands a flagged
+build out at most once per window (120s), so the second flag can land
+inside the first hand-out's window and reach nobody. In the full
+concurrent tier another scenario's tick drains it once the window lapses
+and B finishes anyway; run alone, nothing drains and B waits forever. That
+is the watchdog's job, and this tier deliberately runs none.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._events import (
+    describe_events,
+    resets_by,
+    task_events,
+    wait_until_registered,
+)
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._harness import Deployment
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    task_status,
+    tick_summaries,
+    wait_for_task_status,
+    wait_for_terminal,
+)
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# How long the shared task stays RUNNING before it yields. This is the
+# window B has to *register* in, and it is sized against a cold Modal
+# container for B's bootstrap rather than against anything in the
+# scheduling under test.
+#
+# Registering any later would not fail -- it would quietly test something
+# else. Plan closure follows the dynamic edges once they are written, so a
+# late B pulls the children into its own plan, has running tasks of its
+# own, is never stalled, and never classifies a blocker at all. Correct
+# behaviour, and not this scenario. So the run *checks* that the ordering
+# held rather than trusting this number, and says to raise it if it did
+# not.
+PRE_YIELD_SECONDS = 45
+
+# The SUSPENDED window: how long the children run, and so how long B has
+# to be ticked in. B is flagged the moment the task suspends, so this only
+# has to cover one wake-up and one cold container -- not the whole of B.
+#
+# It cannot go to nothing, though, and the reason is what separates this
+# scenario from the cross-build one. B's *bootstrap* tick already meets the
+# task RUNNING and waits, which is enough to satisfy the counters on its
+# own. What makes this a test of the SUSPENDED case specifically is a tick
+# of B's landing inside this window.
+CHILD_SECONDS = 35
+
+# B stays resident across the whole window -- see the module docstring.
+# This costs nothing in wall clock: a tick exits as soon as its build goes
+# terminal, so the linger is an upper bound that is never reached.
+B_LINGER_SECONDS = 300
+
+STATUS_TIMEOUT_SECONDS = 300
+BUILD_TIMEOUT_SECONDS = 600
+
+
+def test_a_suspended_blocker_is_waited_on_rather_than_reset(
+    deployment: Deployment,
+) -> None:
+    from stardag_integration_tests.registry_live.dag_app import app
+    from stardag_integration_tests.registry_live.tasks import (
+        SuspendingParent,
+        get_sum,
+        square,
+    )
+
+    salt = uuid.uuid4().hex
+
+    shared = SuspendingParent(
+        salt=salt,
+        children=2,
+        child_seconds=CHILD_SECONDS,
+        pre_yield_seconds=PRE_YIELD_SECONDS,
+    )
+
+    build_a = app.build_trigger(
+        get_sum(integers=shared),
+        reactive=True,
+        # A lingers long enough to see its own work through, so the only
+        # build whose progress is in question is B.
+        tick_kwargs={"linger_seconds": 240, "poll_interval_seconds": 3},
+    ).build_id
+
+    # Wait for the state B has to arrive in, rather than sleeping a guess
+    # at how long it takes to get there.
+    wait_for_task_status(
+        shared.id,
+        expected="running",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+    running_at = time.monotonic()
+
+    build_b = app.build_trigger(
+        square(values=shared, offset=5),
+        reactive=True,
+        tick_kwargs={
+            "linger_seconds": B_LINGER_SECONDS,
+            "poll_interval_seconds": 3,
+        },
+    ).build_id
+
+    # B is in, but "in" has to mean *registered against the shared task*,
+    # and registered while it was still RUNNING. Both halves are checked
+    # rather than assumed, because a miss leaves the rest of the test
+    # passing against a different situation.
+    wait_until_registered(deployment, task_id=shared.id, build_id=build_b)
+    # Printed on every run, because PRE_YIELD_SECONDS is the one number
+    # here that is a guess about infrastructure rather than about
+    # scheduling, and this is the evidence for whether it is still the
+    # right guess. A margin trending towards zero is the warning that the
+    # assertion below is about to start failing.
+    margin = PRE_YIELD_SECONDS - (time.monotonic() - running_at)
+    print(
+        f"[suspended] build B registered with {margin:.0f}s of the "
+        f"{PRE_YIELD_SECONDS}s pre-yield window to spare"
+    )
+    status_when_registered = task_status(shared.id)
+    assert status_when_registered == "running", (
+        f"Build B registered against the shared task when it was already "
+        f"{status_when_registered!r}, not RUNNING. Past the yield, plan "
+        "closure pulls the dynamic children into B's plan too, so B has "
+        "work of its own, never stalls, and never classifies a blocker -- "
+        "the scenario silently becomes a different one. Raise "
+        f"PRE_YIELD_SECONDS (currently {PRE_YIELD_SECONDS}s) so B's "
+        "bootstrap fits inside the pre-yield window.\n" + describe(build_b)
+    )
+
+    # The state under test: the worker registered children, yielded and
+    # returned, so the task holds no claim while A progresses them.
+    wait_for_task_status(
+        shared.id,
+        expected="suspended",
+        build_id=build_a,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    # Both builds run to completion. B's is the one in question -- it can
+    # only get there by having waited for the blocker rather than taking
+    # it.
+    status_a = wait_for_terminal(build_a, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_a == "completed", describe(build_a)
+    status_b = wait_for_terminal(build_b, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_b == "completed", (
+        "Build B never finished. It was blocked on a task suspended under "
+        "another build, which then completed.\n"
+        f"--- build A ---\n{describe(build_a)}\n"
+        f"--- build B ---\n{describe(build_b)}"
+    )
+
+    # The decisive observable, and the reason this reads the event log at
+    # all: whether B ever reset a task that was not its to take.
+    events = task_events(deployment, shared.id)
+    resets = resets_by(events, build_b)
+    assert not resets, (
+        "Build B reset the shared task while it was SUSPENDED under build "
+        "A. A suspended task holds no claim, but it is not abandoned: its "
+        "worker registered dynamic children and returned, and A is "
+        "progressing them. Resetting it discards all the pre-yield work "
+        "and races A's scheduling of those children.\n"
+        f"--- events on the shared task ---\n"
+        f"{describe_events(events, A=build_a, B=build_b)}"
+    )
+
+    summaries_b = tick_summaries(build_b)
+    assert_trail_complete(build_b, summaries_b)
+
+    # The same conclusion from the ticks' own account of themselves, which
+    # is what an operator would read. Summed over the whole trail rather
+    # than pinned to one tick: the claim is that *no* tick of B ever reset
+    # the blocker, which is both stronger and independent of how many
+    # wake-ups B happened to get.
+    reset_count = sum(s.get("in_build_blockers_reset", 0) for s in summaries_b)
+    assert reset_count == 0, (
+        f"Build B's ticks reset a blocker in its own plan {reset_count} "
+        "time(s). The shared task is the only blocker there, and it was "
+        "not B's to take.\n" + describe(build_b)
+    )
+    waited = sum(s.get("external_blockers_waited", 0) for s in summaries_b)
+    assert waited >= 1, (
+        "No tick of build B ever reported waiting on an external blocker, "
+        "so B never met the shared task as one -- it may have raced past "
+        "the window and scheduled work of its own instead. Nothing above "
+        "this line is meaningful in that case.\n" + describe(build_b)
+    )
+    fatal = sum(s.get("external_blockers_fatal", 0) for s in summaries_b)
+    assert fatal == 0, (
+        "Build B treated the suspended task as a fatal blocker. A task "
+        "mid-flight in another build is a wait, not a failure.\n" + describe(build_b)
+    )
+
+    # B never ran a second copy: it waited for A's, then used the output.
+    # Its own spawns are its root alone.
+    spawned_b = sum(s.get("spawned", 0) for s in summaries_b)
+    assert spawned_b == 1, (
+        f"Build B spawned {spawned_b} task(s); it should have spawned only "
+        "its own root, having waited for the suspended task rather than "
+        "starting a second copy of it.\n" + describe(build_b)
+    )

--- a/integration-tests/tests_registry_live/test_suspended_blocker.py
+++ b/integration-tests/tests_registry_live/test_suspended_blocker.py
@@ -45,21 +45,24 @@ is the watchdog's job, and this tier deliberately runs none.
 
 from __future__ import annotations
 
-import time
 import uuid
+from datetime import datetime
 
 import pytest
 
 from stardag_integration_tests.registry_live._events import (
     describe_events,
+    first_event_at,
     resets_by,
     task_events,
     wait_until_registered,
 )
 from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._scenario_app import MAX_LINGER_SECONDS
 from stardag_integration_tests.registry_live._harness import Deployment
 from stardag_integration_tests.registry_live._wait import (
     assert_trail_complete,
+    build_status,
     describe,
     task_status,
     tick_summaries,
@@ -100,9 +103,16 @@ PRE_YIELD_SECONDS = 45
 CHILD_SECONDS = 35
 
 # B stays resident across the whole window -- see the module docstring.
-# This costs nothing in wall clock: a tick exits as soon as its build goes
-# terminal, so the linger is an upper bound that is never reached.
-B_LINGER_SECONDS = 300
+# Read from the app rather than restated: a linger equal to the tick's own
+# Modal timeout is not a tie, because the container's clock starts first,
+# so such a tick is killed instead of exiting through ``lingered_out`` --
+# writing no summary and running no exit hand-off. See MAX_LINGER_SECONDS.
+B_LINGER_SECONDS = MAX_LINGER_SECONDS
+
+# How often B's resident tick re-reads the frontier. Named because the
+# closing assertion is stated in terms of it: the suspended window has to
+# be wide enough that a build polling this often cannot have missed it.
+B_POLL_INTERVAL_SECONDS = 3
 
 STATUS_TIMEOUT_SECONDS = 300
 BUILD_TIMEOUT_SECONDS = 600
@@ -143,14 +153,13 @@ def test_a_suspended_blocker_is_waited_on_rather_than_reset(
         build_id=build_a,
         timeout=STATUS_TIMEOUT_SECONDS,
     )
-    running_at = time.monotonic()
 
     build_b = app.build_trigger(
         square(values=shared, offset=5),
         reactive=True,
         tick_kwargs={
             "linger_seconds": B_LINGER_SECONDS,
-            "poll_interval_seconds": 3,
+            "poll_interval_seconds": B_POLL_INTERVAL_SECONDS,
         },
     ).build_id
 
@@ -159,16 +168,7 @@ def test_a_suspended_blocker_is_waited_on_rather_than_reset(
     # rather than assumed, because a miss leaves the rest of the test
     # passing against a different situation.
     wait_until_registered(deployment, task_id=shared.id, build_id=build_b)
-    # Printed on every run, because PRE_YIELD_SECONDS is the one number
-    # here that is a guess about infrastructure rather than about
-    # scheduling, and this is the evidence for whether it is still the
-    # right guess. A margin trending towards zero is the warning that the
-    # assertion below is about to start failing.
-    margin = PRE_YIELD_SECONDS - (time.monotonic() - running_at)
-    print(
-        f"[suspended] build B registered with {margin:.0f}s of the "
-        f"{PRE_YIELD_SECONDS}s pre-yield window to spare"
-    )
+    _report_margin(deployment, shared_id=shared.id, build_id=build_b)
     status_when_registered = task_status(shared.id)
     assert status_when_registered == "running", (
         f"Build B registered against the shared task when it was already "
@@ -187,6 +187,25 @@ def test_a_suspended_blocker_is_waited_on_rather_than_reset(
         expected="suspended",
         build_id=build_a,
         timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    # Half of the scenario's defining precondition: B is alive at the
+    # moment the task suspends. The other half -- that the suspended window
+    # was wide enough for B's poll to land inside it -- is checked after
+    # the run, from the event log's own clock. Together they are what makes
+    # this the SUSPENDED case rather than a second copy of the RUNNING one.
+    #
+    # It needs saying because the tick counters cannot do this job. B's
+    # bootstrap tick already meets the task RUNNING and waits, so
+    # `external_blockers_waited >= 1` is satisfied before the yield ever
+    # happens; on its own it would let this scenario decay into what
+    # `test_cross_build_wake` already covers, and still pass.
+    status_b_now = build_status(build_b)
+    assert status_b_now == "running", (
+        f"Build B was already {status_b_now!r} by the time the shared task "
+        "suspended, so it never met the blocker in the state this scenario "
+        "exists to test -- everything below would be about the RUNNING "
+        "case, which is covered elsewhere.\n" + describe(build_b)
     )
 
     # Both builds run to completion. B's is the one in question -- it can
@@ -237,6 +256,28 @@ def test_a_suspended_blocker_is_waited_on_rather_than_reset(
         "the window and scheduled work of its own instead. Nothing above "
         "this line is meaningful in that case.\n" + describe(build_b)
     )
+    # The other half of the precondition, from the registry's clock: the
+    # task really did sit suspended for long enough that a build polling
+    # every B_POLL_INTERVAL_SECONDS, and shown above to be alive when it
+    # suspended, must have evaluated it in that state.
+    suspended_for = _suspended_window_seconds(events)
+    assert suspended_for is not None, (
+        "The shared task's event log records no suspension at all, so the "
+        "state this scenario is named for never existed.\n"
+        f"--- events on the shared task ---\n"
+        f"{describe_events(events, A=build_a, B=build_b)}"
+    )
+    assert suspended_for >= 4 * B_POLL_INTERVAL_SECONDS, (
+        f"The shared task was suspended for only {suspended_for:.0f}s, "
+        f"which is too close to B's {B_POLL_INTERVAL_SECONDS}s poll "
+        "interval to conclude B ever saw it in that state -- so the "
+        "assertions above may all be about the RUNNING case, which is "
+        f"covered elsewhere. Raise CHILD_SECONDS (currently "
+        f"{CHILD_SECONDS}s).\n"
+        f"--- events on the shared task ---\n"
+        f"{describe_events(events, A=build_a, B=build_b)}"
+    )
+
     fatal = sum(s.get("external_blockers_fatal", 0) for s in summaries_b)
     assert fatal == 0, (
         "Build B treated the suspended task as a fatal blocker. A task "
@@ -251,3 +292,53 @@ def test_a_suspended_blocker_is_waited_on_rather_than_reset(
         "its own root, having waited for the suspended task rather than "
         "starting a second copy of it.\n" + describe(build_b)
     )
+
+
+def _report_margin(deployment: Deployment, *, shared_id, build_id) -> None:
+    """Print how much of the pre-yield window B had left when it registered.
+
+    Printed on every run because ``PRE_YIELD_SECONDS`` is the one number in
+    this file that is a guess about infrastructure rather than about
+    scheduling, and this is the evidence for whether it is still the right
+    guess. A margin trending towards zero is the warning that the assertion
+    below it is about to start failing.
+
+    Both timestamps come from the **registry's** clock -- when the task
+    started, and when this build first recorded an event against it.
+    Measuring from when a client poll happened to notice the transition
+    instead would overstate the remaining window by up to a poll interval
+    plus a round trip, which is exactly the direction that makes an early
+    warning useless.
+    """
+    from stardag.registry import registry_provider
+
+    started_at = registry_provider.get().task_get_metadata(shared_id).started_at
+    registered_at = first_event_at(task_events(deployment, shared_id), build_id)
+    if started_at is None or registered_at is None:
+        print("[suspended] margin unavailable (missing registry timestamps)")
+        return
+    elapsed = (datetime.fromisoformat(registered_at) - started_at).total_seconds()
+    print(
+        f"[suspended] build B registered {elapsed:.0f}s after the task "
+        f"started, leaving {PRE_YIELD_SECONDS - elapsed:.0f}s of the "
+        f"{PRE_YIELD_SECONDS}s pre-yield window"
+    )
+
+
+def _suspended_window_seconds(events) -> float | None:
+    """How long the task sat SUSPENDED, by the registry's clock.
+
+    From ``task_suspended`` to whatever ended it. ``None`` when no
+    suspension was recorded at all, which is a different failure and is
+    reported as one.
+    """
+    for position, event in enumerate(events):
+        if event.get("event_type") != "task_suspended":
+            continue
+        suspended_at = datetime.fromisoformat(str(event["created_at"]))
+        for later in events[position + 1 :]:
+            if later.get("event_type") != "task_suspended":
+                ended_at = datetime.fromisoformat(str(later["created_at"]))
+                return (ended_at - suspended_at).total_seconds()
+        return None
+    return None

--- a/integration-tests/tests_registry_live/test_wake_storm.py
+++ b/integration-tests/tests_registry_live/test_wake_storm.py
@@ -1,0 +1,162 @@
+"""One task completing wakes several dormant builds -- each exactly once.
+
+The two-build wake-up next door shows the news travels. This shows it does
+not multiply, which is a separate property and the one that decides whether
+the mechanism is usable at all.
+
+The hazard is structural rather than incidental. When a shared task
+completes, *every* build holding it is flagged in one write, and several
+independent things then go looking for flagged builds: the worker that
+wrote the status, the owning build's tick on its next pass, and that tick
+again on its way out. Nothing coordinates them. The naive outcome is every
+drainer spawning a tick for every flagged build -- a container per
+(notifier x neighbour) pair, which grows quadratically with exactly the
+contention that makes wake-ups matter in the first place.
+
+What prevents it is that the *hand-out* is a write, not a read: asking for
+wake candidates stamps each build it returns, and a build already stamped
+inside the window is handed to nobody else. So the bound is one tick per
+flagged build per window, however many notifiers ask and however close
+together.
+
+That is invisible with two builds, where one spawn and a storm look the
+same. It needs a neighbourhood.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    tick_summaries,
+    wait_for_task_status,
+    wait_for_terminal,
+)
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# Enough neighbours that one spawn each and a storm are different numbers.
+# Three is the smallest count that shows the difference, and each one is a
+# real Modal container, so it is the count used.
+NEIGHBOURS = 3
+
+# The shared task must outlive every neighbour's linger by a clear margin,
+# so that when it completes there is provably no scheduler anywhere for any
+# of them.
+SHARED_SLEEP_SECONDS = 75
+NEIGHBOUR_LINGER_SECONDS = 15
+
+# A build is handed out at most once per this window, server-side. The
+# assertion below is really a statement about it: every notifier draining
+# in the seconds after the shared task completes falls inside one window.
+WAKE_HANDOUT_WINDOW_SECONDS = 120
+
+STATUS_TIMEOUT_SECONDS = 300
+BUILD_TIMEOUT_SECONDS = 600
+
+
+def test_many_dormant_builds_are_each_woken_once() -> None:
+    from stardag_integration_tests.registry_live.dag_app import app
+    from stardag_integration_tests.registry_live.tasks import (
+        get_range,
+        get_sum,
+        slow,
+        square,
+    )
+
+    salt = uuid.uuid4().hex
+
+    leaf = get_range(limit=8, salt=salt)
+    shared = slow(values=leaf, seconds=SHARED_SLEEP_SECONDS)
+
+    owner = app.build_trigger(
+        get_sum(integers=shared),
+        reactive=True,
+        # The owner stays resident through its own work: every build whose
+        # progress is in question should be a neighbour.
+        tick_kwargs={"linger_seconds": 200, "poll_interval_seconds": 3},
+    ).build_id
+
+    # Let the owner claim and start the shared task before the neighbours
+    # arrive, so they meet it RUNNING and wait rather than racing for it.
+    wait_for_task_status(
+        shared.id,
+        expected="running",
+        build_id=owner,
+        timeout=STATUS_TIMEOUT_SECONDS,
+    )
+
+    # Each neighbour has a root of its own, so these are genuinely N builds
+    # with N plans that overlap, not one plan triggered N times.
+    neighbours = [
+        app.build_trigger(
+            square(values=shared, offset=offset),
+            reactive=True,
+            tick_kwargs={
+                "linger_seconds": NEIGHBOUR_LINGER_SECONDS,
+                "poll_interval_seconds": 3,
+            },
+        ).build_id
+        for offset in range(1, NEIGHBOURS + 1)
+    ]
+
+    status_owner = wait_for_terminal(owner, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status_owner == "completed", describe(owner)
+
+    for index, build_id in enumerate(neighbours):
+        status = wait_for_terminal(build_id, timeout=BUILD_TIMEOUT_SECONDS)
+        assert status == "completed", (
+            f"Neighbour {index} never finished after the shared task "
+            "completed.\n"
+            f"--- owner ---\n{describe(owner)}\n"
+            f"--- neighbour {index} ---\n{describe(build_id)}"
+        )
+
+    for index, build_id in enumerate(neighbours):
+        summaries = tick_summaries(build_id)
+        assert_trail_complete(build_id, summaries)
+
+        # Dormant when the news arrived: its own tick gave up and left.
+        assert summaries[0].get("outcome") == "lingered_out", (
+            f"Neighbour {index}'s first tick did not linger out, so it may "
+            "have been resident when the shared task completed and noticed "
+            f"on its own poll. The shared sleep ({SHARED_SLEEP_SECONDS}s) "
+            f"must comfortably outlast the linger "
+            f"({NEIGHBOUR_LINGER_SECONDS}s).\n" + describe(build_id)
+        )
+
+        # The property this scenario exists for. One tick after the
+        # bootstrap is the woken one; a second is tolerated because the
+        # owning tick's exit hand-off can genuinely race a drain, and it
+        # costs one container that finds the lease held and leaves. Three
+        # or more is the storm: several notifiers each spawning for the
+        # same build, which is what the hand-out stamp prevents.
+        woken = len(summaries) - 1
+        assert 1 <= woken <= 2, (
+            f"Neighbour {index} ran {woken} tick(s) after its bootstrap; "
+            "expected 1 (the wake-up), or 2 if the exit hand-off raced a "
+            "drain. More than that means several notifiers each spawned a "
+            "tick for the same build, so the wake-candidate hand-out is "
+            "not stamping builds as it hands them out -- within one "
+            f"{WAKE_HANDOUT_WINDOW_SECONDS}s window a build must be handed "
+            "to exactly one caller.\n" + describe(build_id)
+        )
+
+        # It waited for the owner's copy rather than running a second one:
+        # its own spawns are its root alone.
+        spawned = sum(s.get("spawned", 0) for s in summaries)
+        assert spawned == 1, (
+            f"Neighbour {index} spawned {spawned} task(s); it should have "
+            "spawned only its own root, having waited for the shared task "
+            "rather than running a second copy.\n" + describe(build_id)
+        )

--- a/integration-tests/tests_registry_live/test_wake_storm.py
+++ b/integration-tests/tests_registry_live/test_wake_storm.py
@@ -135,21 +135,41 @@ def test_many_dormant_builds_are_each_woken_once() -> None:
             f"({NEIGHBOUR_LINGER_SECONDS}s).\n" + describe(build_id)
         )
 
-        # The property this scenario exists for. One tick after the
-        # bootstrap is the woken one; a second is tolerated because the
-        # owning tick's exit hand-off can genuinely race a drain, and it
-        # costs one container that finds the lease held and leaves. Three
-        # or more is the storm: several notifiers each spawning for the
-        # same build, which is what the hand-out stamp prevents.
-        woken = len(summaries) - 1
-        assert 1 <= woken <= 2, (
-            f"Neighbour {index} ran {woken} tick(s) after its bootstrap; "
-            "expected 1 (the wake-up), or 2 if the exit hand-off raced a "
-            "drain. More than that means several notifiers each spawned a "
-            "tick for the same build, so the wake-candidate hand-out is "
-            "not stamping builds as it hands them out -- within one "
-            f"{WAKE_HANDOUT_WINDOW_SECONDS}s window a build must be handed "
-            "to exactly one caller.\n" + describe(build_id)
+        # It was woken at all.
+        assert len(summaries) > 1, (
+            f"Neighbour {index} ran exactly one tick, so it was never "
+            "woken.\n" + describe(build_id)
+        )
+
+        # The property this scenario exists for, measured by the outcome
+        # that means "a container started for a build somebody else was
+        # already driving". That is what a redundant spawn *is*, and
+        # counting those is not the same as counting ticks.
+        #
+        # An earlier version bounded the total tick count instead, and it
+        # conflated two unrelated things. A neighbour's woken tick spawns
+        # its own root and then re-arms only the linger it was triggered
+        # with; the deadline resets on an action, so a root whose container
+        # start plus run outlasts that linger costs a further tick --
+        # legitimately, spawned by its own worker. The count would then
+        # trip and the message would blame the hand-out stamp for
+        # something that is just a cold container.
+        #
+        # ``lease_held`` cannot be reached that way: it means a tick
+        # arrived while another held the lease for the same build. One is
+        # allowed, because the owning tick's exit hand-off can genuinely
+        # race a drain. Several is the storm the hand-out stamp exists to
+        # prevent -- every notifier spawning for every flagged build.
+        contended = sum(1 for s in summaries if s.get("outcome") == "lease_held")
+        assert contended <= 1, (
+            f"Neighbour {index} had {contended} tick(s) find the scheduler "
+            "lease already held, so that many redundant containers were "
+            "started for one build. At most one is expected (the exit "
+            "hand-off racing a drain); more means several notifiers each "
+            "spawned a tick for the same build, so the wake-candidate "
+            "hand-out is not stamping builds as it hands them out -- "
+            f"within one {WAKE_HANDOUT_WINDOW_SECONDS}s window a build "
+            "must be handed to exactly one caller.\n" + describe(build_id)
         )
 
         # It waited for the owner's copy rather than running a second one:

--- a/integration-tests/tests_registry_live/test_watchdog_sweep.py
+++ b/integration-tests/tests_registry_live/test_watchdog_sweep.py
@@ -1,0 +1,191 @@
+"""The watchdog sweep dispatches: it spawns a tick per build and returns.
+
+The sweep is the safety net under everything else here -- what catches a
+wake-up that was never delivered, a build abandoned RUNNING, a state change
+nobody wrote an event for. It is also the one mechanism in this tier that
+nothing else can exercise incidentally, because every other scenario
+depends on it *not* running.
+
+The contract has two halves, and the first is a cost:
+
+**It dispatches rather than schedules.** It lists the app's running builds,
+spawns one ``tick`` each, and returns -- in seconds, whatever the number of
+builds. An earlier design ran every tick body sequentially inside the
+sweep's own container, which made three things a function of how many
+builds the environment happened to be running: each build's spawn cap (that
+one container's timeout divided across the sweep), the latency for the last
+build in the list, and whether the sweep finished at all. So the elapsed
+time of the call is an observable, not instrumentation: an implementation
+that inlined the work would be correct in every other respect and would
+show up here as a call that takes as long as the work does.
+
+**Each build gets its own container, and its own full timeout.** Which is
+what makes a swept tick indistinguishable from any other tick, rather than
+a degraded one.
+
+What a swept tick does *not* get is a linger. That is deliberate and it is
+the opposite of a wake-up's tick: a wake-up means something changed and
+more probably will, while a sweep's population is by construction builds
+where nothing is known to have happened. Lingering there would spend
+container time on the builds least likely to have anything to do -- and
+because a container's lifetime is the maximum over its live inputs, a
+couple of stale RUNNING builds would keep the tick function warm for
+nothing.
+
+**Why this scenario has an app to itself.** The sweep lists running builds
+scoped by *reactive app name*. Every scenario in this tier runs
+concurrently in one Modal environment, so a sweep driven against the shared
+app would spawn ticks for whatever else was running at that moment --
+waking the dormant builds that four other scenarios assert cannot be woken
+by anything but the mechanism they are testing. They would not fail; they
+would quietly stop meaning anything. A second app name is the whole
+isolation, and it is cheap: the image is identical.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._deployed import run_watchdog_sweep
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._harness import Deployment
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    tick_summaries,
+    wait_for_terminal,
+    wait_until,
+)
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# Builds for the sweep to find. More than one, because the whole question
+# is what the sweep does with N of them; three keeps the container cost
+# down while still making "one tick each" a different number from "one tick
+# total" and from "N x N".
+SWEPT_BUILDS = 3
+
+# Each build's own task runs long enough that all three are still RUNNING
+# when the sweep happens -- a build that finished on its own is not a build
+# the sweep had anything to do for.
+SLOW_SECONDS = 90
+
+# ...and each build's own scheduler gives up well before that, so nothing
+# of theirs is alive when the sweep runs. Otherwise a swept tick would find
+# the scheduler lease held and exit, and the sweep would look ineffective.
+LINGER_SECONDS = 10
+
+# What "returns in seconds" is held to. Generous by an order of magnitude
+# against the thing it is distinguishing from: inlining three tick bodies
+# would take minutes, since each would linger or poll through real work.
+# Loose enough not to flake on a slow container start for the sweep itself.
+SWEEP_BUDGET_SECONDS = 60
+
+DORMANT_TIMEOUT_SECONDS = 300
+BUILD_TIMEOUT_SECONDS = 600
+
+
+def test_one_sweep_spawns_one_tick_per_build_and_returns(
+    deployment: Deployment,
+) -> None:
+    from stardag_integration_tests.registry_live.tasks import (
+        get_range,
+        get_sum,
+        slow,
+    )
+    from stardag_integration_tests.registry_live.watchdog_app import APP_NAME, app
+
+    salt = uuid.uuid4().hex
+
+    builds = [
+        app.build_trigger(
+            get_sum(
+                integers=slow(
+                    values=get_range(limit=8 + index, salt=salt),
+                    seconds=SLOW_SECONDS,
+                )
+            ),
+            reactive=True,
+            tick_kwargs={
+                "linger_seconds": LINGER_SECONDS,
+                "poll_interval_seconds": 3,
+            },
+        ).build_id
+        for index in range(SWEPT_BUILDS)
+    ]
+
+    # Every build's own scheduler must be gone before the sweep, or the
+    # sweep's ticks would simply find the lease held. Waiting for the
+    # observable -- a first tick that lingered out -- rather than sleeping
+    # long enough for it to be likely.
+    for index, build_id in enumerate(builds):
+        wait_until(
+            lambda build_id=build_id: any(
+                summary.get("outcome") == "lingered_out"
+                for summary in tick_summaries(build_id)
+            ),
+            build_id=build_id,
+            timeout=DORMANT_TIMEOUT_SECONDS,
+            poll_interval=3.0,
+            what=(
+                f"build {index}'s own tick to linger out, leaving it "
+                "dormant with work still running"
+            ),
+        )
+
+    ticks_before = {build_id: len(tick_summaries(build_id)) for build_id in builds}
+
+    elapsed = run_watchdog_sweep(
+        app_name=APP_NAME, modal_environment=deployment.modal_environment
+    )
+
+    # The cost half of the contract.
+    assert elapsed < SWEEP_BUDGET_SECONDS, (
+        f"The sweep took {elapsed:.0f}s for {SWEPT_BUILDS} builds. It is "
+        "supposed to list them, spawn a tick each and return -- a duration "
+        "independent of how many it found. Taking this long means it ran "
+        "the tick bodies itself, which also gives each build a share of "
+        "one container's timeout instead of its own."
+    )
+
+    # ...and the effect half: every build got a tick it did not have
+    # before. Counting from a baseline rather than from zero because these
+    # builds each ran their own bootstrap tick already.
+    for index, build_id in enumerate(builds):
+        wait_until(
+            lambda build_id=build_id: len(tick_summaries(build_id))
+            > ticks_before[build_id],
+            build_id=build_id,
+            timeout=DORMANT_TIMEOUT_SECONDS,
+            poll_interval=3.0,
+            what=(
+                f"build {index} to record a tick from the sweep (it had "
+                f"{ticks_before[build_id]} before)"
+            ),
+        )
+
+    # The sweep is a safety net, so the builds it swept should also finish.
+    for index, build_id in enumerate(builds):
+        status = wait_for_terminal(build_id, timeout=BUILD_TIMEOUT_SECONDS)
+        assert status == "completed", (
+            f"Build {index} did not complete after being swept.\n" + describe(build_id)
+        )
+        summaries = tick_summaries(build_id)
+        assert_trail_complete(build_id, summaries)
+
+        # Each task ran once: a sweep that spawns a tick for a build whose
+        # work is already in flight must not start a second copy of it.
+        # leaf, slow, root.
+        spawned = sum(s.get("spawned", 0) for s in summaries)
+        assert spawned == 3, (
+            f"Build {index} spawned {spawned} tasks for a three-task plan. "
+            "A swept tick arriving while the build's own work is running "
+            "must not respawn it.\n" + describe(build_id)
+        )

--- a/integration-tests/tests_registry_live/test_wide_fan_out.py
+++ b/integration-tests/tests_registry_live/test_wide_fan_out.py
@@ -62,11 +62,15 @@ WIDTH = 24
 # provoked.
 MAX_SPAWNS_PER_TICK = 8
 
-# One tick should see the whole build through, so that what is under test
-# is a *pass* boundary rather than a container boundary. Without the
-# linger, each truncated pass would end the tick and the next pass would
-# arrive as a wake-up -- which is a different mechanism, tested elsewhere,
-# and would hide whether the pass loop resumes on its own.
+# Long enough that one tick can carry the whole build, so what is under
+# test is a *pass* boundary rather than a container boundary: without it,
+# each truncated pass would end the tick and the next pass would arrive as
+# a wake-up, which is a different mechanism tested elsewhere.
+#
+# Nothing below *asserts* that only one tick ran, and deliberately not --
+# the spawn-count assertion is the real subject and holds however the
+# passes were distributed across containers, so pinning the tick count
+# would only add a way to fail for reasons that are not the point.
 LINGER_SECONDS = 150
 
 # WIDTH leaves plus the single root that joins them.

--- a/integration-tests/tests_registry_live/test_wide_fan_out.py
+++ b/integration-tests/tests_registry_live/test_wide_fan_out.py
@@ -1,0 +1,126 @@
+"""A layer wider than one pass may spawn still completes, once per task.
+
+A tick lives in a container with a finite life, so "spawn everything that is
+actionable" is a bound on nothing: a wide enough layer outlives the
+container and the tick is killed mid-fan-out. The per-pass spawn cap exists
+to stop that, and the interesting claim about it is not the number -- it is
+that hitting it is a **throttle rather than a stall**. The pass acted, it
+did as much as it had budget for, and what it left is picked up on the next
+pass. Nothing is dropped and nothing is started twice.
+
+**Why the cap is set explicitly here rather than being provoked by width.**
+The cap is derived from the tick container's own wall-clock limit, and for
+this deployment that derivation lands near two thousand -- a layer wide
+enough to reach it would be thousands of real Modal containers, which is
+not a test, it is a bill. The derivation itself is not in question: which
+duration it reads, down a four-rung ladder, is covered exhaustively by unit
+tests, including the Modal integration passing the deployed ``tick``
+function's registered timeout into it. Re-proving that here would be
+expensive duplication of something already settled.
+
+What is *not* covered anywhere else is what this asks: a real tick, fanning
+out to real workers reporting to a real registry, running into its cap and
+carrying on correctly. Setting the cap low makes that path reachable at a
+width that costs two dozen containers instead of two thousand.
+
+The width still has to be real, though. The leaves are independent and
+carry distinct ids, so they are genuinely N actionable tasks in one layer --
+a fan-out rather than a deduplication test -- and registering a plan of this
+size against a deployed registry over the network is itself part of what
+gets exercised.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from stardag_integration_tests.registry_live._guard import registry_live_guard
+from stardag_integration_tests.registry_live._wait import (
+    assert_trail_complete,
+    describe,
+    tick_summaries,
+    wait_for_terminal,
+)
+
+registry_live_guard()
+
+pytestmark = [
+    pytest.mark.registry_live,
+    pytest.mark.timeout(900),
+]
+
+# The width of the one layer. Every leaf is a real Modal container, so this
+# is chosen as the smallest number that is comfortably several times the
+# cap below -- enough that the fan-out is spread over several passes rather
+# than two.
+WIDTH = 24
+
+# Deliberately far below anything the deployment would derive, so the pass
+# truncates. See the module docstring for why this is set rather than
+# provoked.
+MAX_SPAWNS_PER_TICK = 8
+
+# One tick should see the whole build through, so that what is under test
+# is a *pass* boundary rather than a container boundary. Without the
+# linger, each truncated pass would end the tick and the next pass would
+# arrive as a wake-up -- which is a different mechanism, tested elsewhere,
+# and would hide whether the pass loop resumes on its own.
+LINGER_SECONDS = 150
+
+# WIDTH leaves plus the single root that joins them.
+TASKS_IN_PLAN = WIDTH + 1
+
+BUILD_TIMEOUT_SECONDS = 600
+
+
+def test_a_layer_wider_than_one_pass_completes_once_per_task() -> None:
+    from stardag_integration_tests.registry_live.dag_app import app
+    from stardag_integration_tests.registry_live.tasks import FanIn
+
+    salt = uuid.uuid4().hex
+
+    build_id = app.build_trigger(
+        FanIn(salt=salt, width=WIDTH),
+        reactive=True,
+        tick_kwargs={
+            "max_spawns_per_tick": MAX_SPAWNS_PER_TICK,
+            "linger_seconds": LINGER_SECONDS,
+            "poll_interval_seconds": 3,
+        },
+    ).build_id
+
+    status = wait_for_terminal(build_id, timeout=BUILD_TIMEOUT_SECONDS)
+    assert status == "completed", (
+        f"A {WIDTH}-wide layer under a per-pass cap of "
+        f"{MAX_SPAWNS_PER_TICK} did not complete. A truncated pass is "
+        "supposed to be a throttle, not a stall: the tick spawns what it "
+        "has budget for and picks the rest up on its next pass.\n" + describe(build_id)
+    )
+
+    summaries = tick_summaries(build_id)
+    assert_trail_complete(build_id, summaries)
+
+    # One spawn per task across every pass of every tick. This is the
+    # assertion that truncation is clean: the tasks a pass declined to
+    # start have to be started later exactly once, and the ones it did
+    # start must not be started again when the next pass re-reads a
+    # frontier that still lists them as it left them.
+    spawned = sum(s.get("spawned", 0) for s in summaries)
+    assert spawned == TASKS_IN_PLAN, (
+        f"{spawned} spawns for {TASKS_IN_PLAN} tasks. Above it, a "
+        "truncated pass re-spawned work the previous pass had already "
+        "started -- though an interrupted worker also legitimately "
+        "respawns, so check the trail's interruption counters first. Below "
+        "it, a task the cap deferred was never picked up.\n" + describe(build_id)
+    )
+
+    # No tick died. A tick that ran out of container while fanning out
+    # would not report at all, so this catches the other shape: one that
+    # reported an error rather than a clean outcome.
+    errored = [s for s in summaries if s.get("outcome") == "error"]
+    assert not errored, (
+        f"{len(errored)} tick(s) ended in an error while fanning out over "
+        f"a {WIDTH}-wide layer.\n" + describe(build_id)
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -195,11 +195,15 @@ commands_pre =
 # which serves them concurrently, and each salts its own task ids.
 #
 # A fixed worker count rather than `-n auto`: auto sizes to the machine's
-# CPUs, which on a laptop meant sixteen processes for three I/O-bound
-# tests -- sixteen interpreter startups, and sixteen copies of the guard's
-# start-up round trip against a registry that is deliberately one
-# container. Four covers the scenarios with headroom; raise it if the tier
-# grows well past that.
+# CPUs, which bears no relation to the work here -- these tests are almost
+# entirely sleep, and a laptop's count would mean that many interpreter
+# startups and that many copies of the guard's start-up round trip against
+# a registry that is deliberately one container.
+#
+# Sized to the number of scenarios instead, which is the quantity that
+# matters: anything less and the tier's wall clock becomes the sum of two
+# batches rather than the length of the slowest scenario. Raise it in step
+# with the scenario count.
 #
 # **To debug a failure, run them one at a time**: the shared registry and
 # interleaved logs make a low-level bug much harder to read concurrently.
@@ -212,7 +216,7 @@ commands_pre =
 #
 # In CI the same switch is the `serial` input on workflow_dispatch.
 commands =
-    uv run pytest -n 4 {posargs:tests_registry_live}
+    uv run pytest -n 12 {posargs:tests_registry_live}
 
 [testenv:integration-browser]
 description = Run integration tests including browser tests (requires docker-compose up)


### PR DESCRIPTION
Six behaviours that were only ever verified by hand — someone running a
script and reading the output — now have scenario modules that assert an
observable. The harness itself was already stable; this is additive.

## What each scenario asks

| Module | The question |
| --- | --- |
| `test_suspended_blocker` | A task SUSPENDED on its dynamic children holds **no claim**. Is it waited on, or reset? |
| `test_failed_blocker` | A shared task *failed*. Is that a result to leave alone, or a revocation to reset? |
| `test_limit_slot_wake` | A concurrency slot frees. Is the build queued on it woken, though it shares no task with the holder? |
| `test_wake_storm` | Several dormant builds flagged at once. One tick each, or one per notifier? |
| `test_watchdog_sweep` | Does one sweep spawn a tick per build and return in seconds? |
| `test_wide_fan_out` | A layer wider than one pass may spawn — throttle, or stall? |

## Three decisions worth reviewing

**The watchdog gets its own app.** `tick_watchdog` is registered
unconditionally (only its *schedule* is gated on
`watchdog_period_minutes`), so it can be driven on demand — but that alone
is not enough. `_run_watchdog_sweep` lists running builds scoped by
**reactive app name**, and every scenario shares one Modal environment, so
a sweep against the shared app would spawn ticks for whatever else was
running and wake the dormant builds that four other scenarios assert
cannot be woken by anything but the mechanism under test. They would not
fail; they would quietly stop meaning anything. `registry-live-watchdog`
is a second app in the *same* environment — the environment stays the unit
of teardown, the image is identical, and the extra deploy costs ~9s.

**The wide fan-out sets its cap rather than provoking it.** With
`tick_settings(timeout=300)` and `max_concurrent_actions=50` the derived
cap is `0.25 × 300 × 50 / 2 = 1875`; reaching it by width would be
thousands of containers. The derivation ladder is already covered
exhaustively by unit tests, including the Modal wiring that feeds the
deployed `tick` function's registered timeout into it — so re-proving it
live would be expensive duplication. What is *not* covered anywhere is a
real tick fanning out to real workers, hitting its cap and carrying on
correctly, and `max_spawns_per_tick=8` over 24 leaves reaches that at two
dozen containers.

**The blocker scenarios read the event log.** Status columns are one row
per task overwritten by whoever wrote last, so a build that resets a task
and then watches another build complete it leaves no mark on them at all.
`GET /api/v1/tasks/{task_id}/events` answers "did build B reset this?"
directly.

## Wait on a state, never on a clock

Every scenario here rests on an ordering — a second build registering
while a task is still RUNNING, a tick landing while one is SUSPENDED — and
a `sleep` sized for that window is wrong in both directions. It is wall
clock on every run, and on the one run where Modal is slow to start a
container it silently produces the situation it was meant to prevent,
leaving a scenario that still passes while testing something weaker.

`_wait.wait_for_task_status` replaces them, including the last blind sleep
in `test_cross_build_wake`. Where a window remains a guess about
*infrastructure* rather than about scheduling, the scenario asserts the
ordering actually held and names the constant to raise if it did not —
which is what makes trimming safe rather than merely faster.
`test_suspended_blocker` prints the margin it had to spare on every run.

## Runtime

Measured on a warm stack, `-n 12`.

| | Before | After |
| --- | --- | --- |
| The four pre-existing modules (6 tests) | ~140s | **119s** |
| Whole tier (12 tests, 10 modules) | — | **207s** |
| Provisioning | ~30s | ~40s (second app) |

| Scenario | s |
| --- | --- |
| `test_suspended_blocker` | 198 |
| `test_watchdog_sweep` | 143 |
| `test_wake_storm` | 124 |
| `test_cross_build_wake` | 122 |
| `test_limit_slot_wake` | 115 |
| `test_failed_blocker` | 98 |
| `test_reactive_e2e` | 83 |
| `test_claim_race` | 82 |
| `test_wide_fan_out` | 44 |
| `test_scheduler_lease_live` (3 tests) | 34 |

So **six new scenarios cost +88s of wall clock**, not the ~600s their
serial sum would be: the tier is bounded by its slowest scenario, and the
trimming pulled that bound down while the additions pushed it up. The
worker count goes `-n 4` → `-n 12`, sized to the scenario count rather
than to a machine's CPUs.

## One finding worth knowing about

`select_wake_candidates` filters on `needs_tick_at IS NOT NULL AND
(tick_requested_at IS NULL OR tick_requested_at < now - 120s)` and does
**not** compare the two timestamps — so a build re-flagged *after* being
handed out is not handed out again until the window lapses.

`test_suspended_blocker`'s first version kept its second build dormant,
which needs waking twice (on suspend, then on complete). It passed in the
full concurrent tier — another scenario's tick drains it once the window
lapses, since drains are not scoped to the caller's build — and hung
indefinitely under `-n0`, which is the mode the docs recommend for
debugging. The blocker scenarios now keep their second build **resident**,
which is the better shape regardless: they are about what a tick *decides*
when it looks at a blocker, not about who called it, and the wake-up path
is tested on its own next door.

The delay is bounded at 120s and the watchdog is the designed backstop, so
this is a trade-off rather than a defect — but `OR needs_tick_at >
tick_requested_at` would close it, at some cost to the storm protection
the window buys. Flagged rather than changed here.

## Verification

Provisioned a stack and ran the tier repeatedly: 12/12 green, and both
blocker scenarios verified **standalone** under `-n0` as well as
concurrently. Ruff, ruff-format and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
