### PR TITLE
Changelog and release notes for v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.23.0] — 2026-09-01
+
 ### SDK
 
 - **Scheduler ticks share a container.** The deployed Modal `tick` is now an
@@ -53,6 +55,23 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   gate, and the documented carve-out for an uncovered _dynamic_ dependency
   registered from inside a worker, which still gets its pickle rather than
   failing the bookkeeping of a task that has already run.
+
+- **`BuildTaskStore` gains async variants** — `save_task_aio` /
+  `save_tasks_aio` / `load_task_aio`, built on the targets' existing
+  `exists_aio` / `open_aio`. The reactive tick's `_load_task` and the async
+  trigger path called the blocking methods straight from the event loop, which
+  stalled every other coroutine in the tick for a network round-trip and drew
+  Modal's `AsyncUsageWarning` on volume-backed roots. The sync methods stay for
+  the sync callers. Also: a corrupt or truncated store pickle now reads as a
+  **miss**, so the tick falls back to registry rehydration instead of raising.
+
+- **Compatible with modal 1.5.5**, which moved two symbols in a patch release:
+  `modal.volume.FileEntryType` → `modal.types.FileEntryType` (still re-exported
+  at runtime, but dropped from the stub, so it broke type checking rather than
+  execution) and `_utils.function_utils.FunctionInfo` → `FunctionSourceInfo`.
+  Both are handled with an import fallback rather than a version floor bump,
+  since the declared `modal>=1.0.0` spans both spellings — verified against
+  1.5.0 and 1.5.5 alike.
 
 - **`--server-version latest` is resolved at deploy time, not deployed as a
   tag.** `stardag self-host up/upgrade --server-version latest` now asks the
@@ -177,6 +196,17 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   half the TTL to a third, so two consecutive renewal failures are
   survivable — and a third is too, because a refused renewal re-acquires
   rather than abandoning a build nothing else is driving.
+
+- _Internal:_ `stardag/build/_reactive.py` (3,412 lines) is now the
+  `_reactive/` package — `_discovery`, `_tick`, `_frontier_actions`,
+  `_terminal`, `_budgets` — split along the section banners the module already
+  had. No behaviour change and no import change: `stardag.build`'s re-exports
+  are untouched and the package `__init__` re-exports what the module did, with
+  one deliberate exception. The **mutable module globals** (the lease timing
+  knobs, the tick-summary route latch, the successor-spawner warning latch) are
+  _not_ re-exported: rebinding an alias leaves the reading module untouched, so
+  a monkeypatch against the package would go green while patching nothing.
+  Reach into the owning submodule instead.
 
 ### Registry API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   changes: the async client's connection pool is sized for a shared process
   rather than for one caller, and the tick's two remaining blocking calls —
   the foreign-app forward and the successor hand-off's spawn — moved off the
-  event loop, where they would have stalled every co-resident tick.
+  event loop, where they would have stalled every co-resident tick. The
+  tick's completion log line now carries `MODAL_TASK_ID`, since packing is
+  otherwise unobservable: `modal app logs` has no per-container attribution
+  and `modal container list` names the app but not the function.
 - **`FunctionSettings` speaks Modal's current vocabulary, and translates the
   old one.** `max_containers`, `min_containers`, `buffer_containers`,
   `scaledown_window`, `max_concurrent_inputs` and `target_concurrent_inputs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 ### SDK
 
 - **Scheduler ticks share a container.** The deployed Modal `tick` is now an
-  `async def` and is registered with `max_concurrent_inputs=10`, so up to ten
-  concurrent reactive builds are served by one container instead of one each.
+  `async def` and is registered with `@modal.concurrent(max_inputs=10)`, so up
+  to ten concurrent reactive builds are served by one container instead of one
+  each — stardag's default for this function, overridable through
+  `FunctionSettings(max_concurrent_inputs=...)`.
   A tick is almost entirely I/O wait — read the frontier, spawn, then poll on
   a sleep until the linger deadline — so this is close to free, and it is what
   makes `linger_seconds` cheap: a resident tick driving level after level no
@@ -22,7 +24,9 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   cached per event loop and closed when the loop changes — so threaded ticks
   would tear down each other's in-flight HTTP client. Workers are deliberately
   not packed (they run user code and may be CPU- or GPU-bound), nor is
-  `tick_watchdog` (its own function, one input per period). Supporting
+  `tick_watchdog` (its own function, one input per period), which shares
+  `tick_settings` with the tick and so is held out explicitly rather than by
+  having no default. Supporting
   changes: the async client's connection pool is sized for a shared process
   rather than for one caller, and the tick's two remaining blocking calls —
   the foreign-app forward and the successor hand-off's spawn — moved off the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,18 +6,87 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
-## v0.23.0 — The reactive scheduler moves onto the build row
+## v0.23.0 — Ten lingering builds per container, not one
+
+Two changes, both about what reactive scheduling costs to keep alive: a
+lingering tick no longer needs a container of its own, and the two things
+it used to derive from elsewhere now live on the build row.
 
 Additive for anyone using the Modal integration as documented; breaking
 only for a custom `RegistryABC` implementation, loudly, in the two ways
-listed under Migration.
+listed under Migration. One fix is worth reading even if you use none of
+this: **an app that set `concurrency_limit`, `keep_warm`,
+`container_idle_timeout` or `allow_concurrent_inputs` on `FunctionSettings`
+could not deploy at all**, and now can.
 
 **Upgrade the registry to server `0.3.0` and redeploy your Modal apps.**
 Unlike the last two releases, the skew here is not free — an upgraded
 registry paired with apps still running an older SDK costs containers
 until each app is redeployed. See Compatibility.
 
-### What changes
+### Ticks share a container
+
+The deployed `tick` is now an `async def` registered with
+`max_concurrent_inputs=10`, so one container serves up to ten concurrent
+reactive builds instead of one each.
+
+A tick is almost entirely I/O wait — read the frontier, spawn, then poll
+on a sleep until the linger deadline — so the packing is close to free.
+It is also what makes `linger_seconds` cheap: the resident tick driving
+level after level, instead of a cold start per level, was exactly what
+kept a container alive per build. Verified live at five concurrent
+lingering builds, all served by one container, all completed.
+
+**Async here is load-bearing, not stylistic.** Modal serves concurrent
+inputs to a _sync_ function on threads, each running its own
+`asyncio.run` and therefore its own event loop. `APIRegistry` is a
+process-wide singleton whose async client is cached per loop and closed
+and rebuilt when the loop changes — so two threaded ticks would tear down
+each other's in-flight HTTP client. Awaiting the body keeps every tick in
+a container on one loop, and therefore on one client.
+
+**What is not packed**, deliberately: workers, which run your code and may
+be CPU- or GPU-bound; the builder, which runs a whole build; the
+bootstrap, which walks a DAG. Nor `tick_watchdog` — it is its own
+function receiving one input per period, so packing would buy nothing in
+the steady state while quietly opting a `def` into the threading above.
+`never_concurrent=True` refuses that combination at registration rather
+than letting Modal accept it silently.
+
+Two supporting changes, each correct per-tick and wrong per-container: the
+async client's connection pool is now sized for a shared process rather
+than for one caller (ten co-resident ticks would otherwise have divided it
+between them, turning a packing win into a latency regression on wide
+frontiers), and the tick's two remaining blocking calls — the foreign-app
+forward and the successor hand-off's spawn — moved off the event loop.
+
+The task-module import deliberately **stays** on the loop: it imports
+arbitrary user modules, and import-time side effects are routinely
+main-thread-only (`signal.signal` raises outright off it), so moving it
+would trade a once-per-container stall for a class of failure that
+surfaces as an unexplained import error in production.
+
+### `FunctionSettings` speaks Modal's current vocabulary
+
+A bug fix, not a deprecation. Modal renamed three container-scaling
+parameters in Feb 2025 and moved input concurrency into `@modal.concurrent`
+in Apr 2025, and its client **raises** `DeprecationError` on the old
+spellings rather than warning. `FunctionSettings` declared all four and
+passed them straight through, so any app that set one of them failed to
+deploy — no behaviour can have depended on that.
+
+It now accepts `max_containers`, `min_containers`, `buffer_containers`,
+`scaledown_window`, `max_concurrent_inputs` and
+`target_concurrent_inputs`, applies the last two via `@modal.concurrent`
+rather than passing them to `App.function()`, and translates the four
+legacy names — `concurrency_limit`, `keep_warm`, `container_idle_timeout`,
+`allow_concurrent_inputs` — with a warning. Validation happens in
+stardag's own vocabulary too: a `target_concurrent_inputs` with no max, or
+above its own max, is refused in the setting names you wrote, rather than
+failing at registration with a `TypeError` naming a parameter you never
+wrote.
+
+### The scheduler moves onto the build row
 
 Two things the reactive tick used to derive now live on the build row
 itself:
@@ -68,7 +137,8 @@ Both skew directions are correct; one of them is expensive.
   their SDK. The new server does not read the legacy lock an old tick
   takes, so it reports `scheduler_live=False` for every completion and
   every worker spawns a tick that immediately no-ops. Correct, but it
-  costs containers until each app is redeployed. **Redeploy promptly.**
+  costs containers until each app is redeployed. **Redeploy promptly** —
+  that redeploy is also what gets you the tick packing above.
 - **Migration:** two nullable columns on `builds` (`b41c7d9e2f08`). No
   backfill — a lease is transient.
 
@@ -78,8 +148,12 @@ plain `stardag self-host upgrade` both land there.
 ### Migration
 
 Nothing to change for documented usage beyond upgrading the registry and
-redeploying the apps. For a **custom `RegistryABC` implementation**, two
-breaking changes, both loud:
+redeploying the apps. If you set container-scaling parameters on
+`FunctionSettings` under Modal's pre-2025 names, they still work and now
+warn; move to the current names at your convenience.
+
+For a **custom `RegistryABC` implementation**, two breaking changes, both
+loud:
 
 - **`task_start_with_limits_aio` is removed.** `task_start_claim_aio`
   gains `claim: bool = True`, so the two orthogonal flags the registry's
@@ -104,6 +178,10 @@ the frontier; grant), so an existing backend needs no changes and can
 override for the cheap reads. `run_tick_aio` **drops its `lock_manager`
 parameter** — the lease was its only use — which affects only code driving
 a tick by hand.
+
+A custom registry backend used from a packed tick should expect
+**concurrent callers in one process** now, which is the constraint the
+async-client note above describes.
 
 ### Also in this release
 
@@ -130,6 +208,10 @@ a tick by hand.
   methods straight from the event loop. A corrupt or truncated store
   pickle also reads as a miss now, so the tick falls back to registry
   rehydration instead of raising.
+- **The tick's completion log line carries `MODAL_TASK_ID`**, which is what
+  makes "how well are ticks packing?" answerable at all: `modal app logs`
+  has no per-container attribution, and `modal container list` names the
+  app but not the function.
 - **Compatible with modal 1.5.5**, which moved `FileEntryType` to
   `modal.types` and renamed `FunctionInfo` in a patch release. Handled
   with an import fallback, so the declared `modal>=1.0.0` still holds.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,8 +29,10 @@ until each app is redeployed. See Compatibility.
 ### Ticks share a container
 
 The deployed `tick` is now an `async def` registered with
-`max_concurrent_inputs=10`, so one container serves up to ten concurrent
-reactive builds instead of one each.
+`@modal.concurrent(max_inputs=10)`, so one container serves up to ten
+concurrent reactive builds instead of one each. That is stardag's default
+for this one function; your own apps set input concurrency through
+`FunctionSettings(max_concurrent_inputs=...)`, which overrides it.
 
 A tick is almost entirely I/O wait — read the frontier, spawn, then poll
 on a sleep until the linger deadline — so the packing is close to free.
@@ -52,8 +54,12 @@ be CPU- or GPU-bound; the builder, which runs a whole build; the
 bootstrap, which walks a DAG. Nor `tick_watchdog` — it is its own
 function receiving one input per period, so packing would buy nothing in
 the steady state while quietly opting a `def` into the threading above.
-`never_concurrent=True` refuses that combination at registration rather
-than letting Modal accept it silently.
+`tick` and `tick_watchdog` are registered from one `tick_settings`, so
+"no default for the watchdog" was not enough — a declared
+`max_concurrent_inputs` would have reached it too. `never_concurrent=True`
+drops input concurrency for the watchdog whatever the shared settings say.
+Modal accepts a sync function with `@modal.concurrent` without complaint,
+so nothing downstream would have caught it.
 
 Two supporting changes, each correct per-tick and wrong per-container: the
 async client's connection pool is now sized for a shared process rather

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,12 +97,13 @@ breaking changes, both loud:
   backend answering with some other shape is gone.
 
 Additive on the same interface: `RegistryABC` gains
-`build_get_notify[_aio]` and
-`build_acquire`/`renew`/`release_scheduler_lease_aio`, all with working
-defaults (delegate to the frontier; grant), so an existing backend needs
-no changes and can override for the cheap reads. `run_tick_aio` **drops
-its `lock_manager` parameter** — the lease was its only use — which
-affects only code driving a tick by hand.
+`build_get_notify` / `build_get_notify_aio`,
+`build_acquire_scheduler_lease_aio`, `build_renew_scheduler_lease_aio` and
+`build_release_scheduler_lease_aio`, all with working defaults (delegate to
+the frontier; grant), so an existing backend needs no changes and can
+override for the cheap reads. `run_tick_aio` **drops its `lock_manager`
+parameter** — the lease was its only use — which affects only code driving
+a tick by hand.
 
 ### Also in this release
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,16 +8,18 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ## v0.23.0 — Ten lingering builds per container, not one
 
-Two changes, both about what reactive scheduling costs to keep alive: a
-lingering tick no longer needs a container of its own, and the two things
-it used to derive from elsewhere now live on the build row.
+The headline is two changes, both about what reactive scheduling costs to
+keep alive: a lingering tick no longer needs a container of its own, and
+the two things it used to derive from elsewhere now live on the build row.
+
+A third fix rides along, independent of both, and is the one worth reading
+even if you use none of this: **an app that set `concurrency_limit`,
+`keep_warm`, `container_idle_timeout` or `allow_concurrent_inputs` on
+`FunctionSettings` could not deploy at all**, and now can.
 
 Additive for anyone using the Modal integration as documented; breaking
 only for a custom `RegistryABC` implementation, loudly, in the two ways
-listed under Migration. One fix is worth reading even if you use none of
-this: **an app that set `concurrency_limit`, `keep_warm`,
-`container_idle_timeout` or `allow_concurrent_inputs` on `FunctionSettings`
-could not deploy at all**, and now can.
+listed under Migration.
 
 **Upgrade the registry to server `0.3.0` and redeploy your Modal apps.**
 Unlike the last two releases, the skew here is not free — an upgraded

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,135 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.23.0 — The reactive scheduler moves onto the build row
+
+Additive for anyone using the Modal integration as documented; breaking
+only for a custom `RegistryABC` implementation, loudly, in the two ways
+listed under Migration.
+
+**Upgrade the registry to server `0.3.0` and redeploy your Modal apps.**
+Unlike the last two releases, the skew here is not free — an upgraded
+registry paired with apps still running an older SDK costs containers
+until each app is redeployed. See Compatibility.
+
+### What changes
+
+Two things the reactive tick used to derive now live on the build row
+itself:
+
+- **The single-flight lease.** It rode on the deprecated global
+  concurrency lock, so both the tick and the registry had to assemble a
+  lock name from a build id and query `distributed_locks`. It is now
+  `builds.scheduler_lease_until` / `scheduler_lease_owner` behind
+  `POST`/`PUT`/`DELETE /builds/{build_id}/scheduler-lease`, and
+  "is a scheduler live?" is a column comparison instead of a second
+  query. Renew and release are owner-checked, so a tick whose lease
+  lapsed and was taken over cannot extend or clear its successor's.
+- **The wake-up flag.** A lingering tick asks "has anything changed?"
+  every few seconds, and used to answer it by fetching the whole
+  frontier — seven statements, one of them a window-function aggregate
+  over the event log — to read a single boolean.
+  `GET /builds/{build_id}/notify` reads the one row. The frontier is
+  fetched only when there is something to act on.
+
+The lease TTL is 60 s, unchanged, and is still the dead-tick recovery
+window. Renewal moved from half the TTL to a third, so two consecutive
+renewal failures are survivable.
+
+**The watchdog sweep now spawns instead of running ticks inline.**
+`tick_watchdog` lists the running reactive builds its app owns, spawns one
+`tick` per build and returns. Three things stop being a function of how
+many builds the environment happens to be running: each build's spawn cap
+(that one container's timeout was divided across the sweep), whether the
+sweep finished at all, and how long the last build in the list waits. A
+swept build's tick still does one pass and exits — a wake-up lingers
+because something just happened, a sweep looks at builds where nothing is
+known to have happened.
+
+### Compatibility
+
+Both skew directions are correct; one of them is expensive.
+
+- **New SDK against an old registry (< `0.3.0`).** No lease routes: the
+  tick runs unleased and says so once. Duplicate ticks become possible —
+  idempotent, and task starts stay arbitrated by the execution claim. The
+  linger poll falls back to the frontier read it did before. That server
+  also reports `scheduler_live=False` to every worker, because it reads a
+  lock table this SDK no longer writes, so wake-ups spawn
+  unconditionally: the pre-lease behaviour end to end, rather than a
+  half-broken one.
+- **New registry against old Modal apps — the direction a real
+  deployment takes**, since the API upgrades before the apps that bake in
+  their SDK. The new server does not read the legacy lock an old tick
+  takes, so it reports `scheduler_live=False` for every completion and
+  every worker spawns a tick that immediately no-ops. Correct, but it
+  costs containers until each app is redeployed. **Redeploy promptly.**
+- **Migration:** two nullable columns on `builds` (`b41c7d9e2f08`). No
+  backfill — a lease is transient.
+
+`DEFAULT_SERVER_VERSION` is now `0.3.0`, so `stardag self-host up` and a
+plain `stardag self-host upgrade` both land there.
+
+### Migration
+
+Nothing to change for documented usage beyond upgrading the registry and
+redeploying the apps. For a **custom `RegistryABC` implementation**, two
+breaking changes, both loud:
+
+- **`task_start_with_limits_aio` is removed.** `task_start_claim_aio`
+  gains `claim: bool = True`, so the two orthogonal flags the registry's
+  single `/start` endpoint carries — `claim` and `enforce_limits` — are
+  reached through one method. Any direct caller migrates to
+  `task_start_claim_aio(..., claim=False)`. An existing
+  `task_start_claim_aio` **override must accept `claim`** or it raises
+  `TypeError` the first time `RegistryConcurrencyLimiter` calls it. A
+  backend that implemented only `task_start_with_limits_aio` and relied on
+  its no-op default now raises `NotImplementedError` from the limiter
+  instead of silently skipping enforcement.
+- **The Modal worker reads `BuildNotifyResult.scheduler_live` off the
+  result directly** instead of through `getattr`. Unknown still spawns —
+  an older registry leaves the field `None` — but the tolerance for a
+  backend answering with some other shape is gone.
+
+Additive on the same interface: `RegistryABC` gains
+`build_get_notify[_aio]` and
+`build_acquire`/`renew`/`release_scheduler_lease_aio`, all with working
+defaults (delegate to the frontier; grant), so an existing backend needs
+no changes and can override for the cheap reads. `run_tick_aio` **drops
+its `lock_manager` parameter** — the lease was its only use — which
+affects only code driving a tick by hand.
+
+### Also in this release
+
+- **`require_pickle_free=True` now binds the scheduler tick, not just the
+  trigger.** It was a trigger-time gate, and a tick is a writer of the
+  same store: on a writable target root a build that declared it writes no
+  pickles quietly left one per task anyway, the first time each was
+  rehydrated. `BuildTaskStore` takes `pickle_free` and the deployed tick
+  builds its store from the app's flag.
+- **`--server-version latest` is resolved at deploy time**, against the
+  GitHub Releases API, rather than handed to `modal.Image.from_registry`
+  as a mutable tag that image caching could serve stale — and
+  `self-host status` can now say which release is running. A deployment
+  recorded as `latest` by an older SDK converts to a pin on its next
+  upgrade.
+- **A plain `stardag self-host upgrade` rolls the server version forward
+  again.** It returned the recorded deployed version unconditionally, so
+  only an explicit `--server-version` could ever move a deployment. It now
+  deploys the newer of the recorded version and `DEFAULT_SERVER_VERSION`,
+  which keeps the anti-downgrade property while letting the pin move a
+  deployment that is behind.
+- **`BuildTaskStore` gains `save_task_aio` / `save_tasks_aio` /
+  `load_task_aio`.** The async call sites used to reach the blocking
+  methods straight from the event loop. A corrupt or truncated store
+  pickle also reads as a miss now, so the tick falls back to registry
+  rehydration instead of raising.
+- **Compatible with modal 1.5.5**, which moved `FileEntryType` to
+  `modal.types` and renamed `FunctionInfo` in a patch release. Handled
+  with an import fallback, so the declared `modal>=1.0.0` still holds.
+
+---
+
 ## v0.22.0 — A finished task wakes every build waiting on it
 
 Additive for anyone using the Modal integration as documented. Reactive


### PR DESCRIPTION
Docs only: stamps `[Unreleased]` as `[0.23.0] — 2026-09-01` in `CHANGELOG.md`
and adds the SDK release-notes entry, *Ten lingering builds per container, not
one*.

Rebased onto `main` after #321 merged, which is the biggest user-facing change
in the release — the release notes lead with it.

## Release notes

Structured around the two changes that both concern what reactive scheduling
costs to keep alive:

1. **Ticks share a container** (#321) — the packing, why async is load-bearing
   rather than stylistic, what is deliberately *not* packed, and the two
   supporting moves off the event loop.
2. **`FunctionSettings` speaks Modal's current vocabulary** (#321) — its own
   section, because it is a bug fix anyone can hit independently of packing:
   Modal's client *raises* on the four pre-2025 names, so an app that set one
   could not deploy at all. Flagged in the intro too, since it is the one fix
   worth reading even for someone using none of the reactive machinery.
3. **The scheduler moves onto the build row** — the lease (#291) and the
   one-row wake-up read (#289), plus the spawning watchdog sweep (#288).

The Compatibility section is the one that matters operationally: unlike
v0.21.0 and v0.22.0, this skew is not free. An upgraded registry paired with
Modal apps still baking an older SDK reports `scheduler_live=False` for every
completion, so every worker spawns a tick that immediately no-ops — correct,
but it costs containers until each app is redeployed. That redeploy is also
what gets you the packing, which the section now says.

Migration is otherwise nothing for documented usage; breaking only for a
custom `RegistryABC`, in the two loud ways the section lists — plus a note
that such a backend should now expect concurrent callers in one process.

## Changelog catch-up

#321's own two entries needed no merge work: they sat at the top of
`### SDK`, which the `[0.23.0]` stamp now covers. Added to its packing entry
only the `MODAL_TASK_ID` log line — a user-visible log format change, so it
belongs somewhere greppable.

Three further changes since v0.22.0 had landed with no changelog line at all:

- **`BuildTaskStore`'s async variants** (#302) — plus the behaviour half of
  that PR: a corrupt or truncated store pickle now reads as a miss rather
  than raising.
- **modal 1.5.5 compatibility** (#319) — `FileEntryType` moved to
  `modal.types` and `FunctionInfo` was renamed, both handled with an import
  fallback rather than a floor bump.
- **The `build/_reactive.py` → `_reactive/` package split** (#305), as an
  internal note. No behaviour or import change, with the one caveat worth
  recording: the mutable module globals are deliberately *not* re-exported,
  so a monkeypatch against the package would go green while patching nothing.

Everything else since v0.22.0 was already written up as it landed.

## No server release with this one

The only `app/` changes since `server-v0.3.0` are dependabot minor/patch
bumps. The API's are **lockfile-only** — the image builds
`uv pip install .` from `pyproject.toml`, which is untouched — and the UI's
are dev tooling apart from an `@xyflow/react` patch. No HTTP surface change
and no migration, so the "release after each significant Registry API or UI
change" cadence does not fire. #321 touches no `app/` code either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)